### PR TITLE
controllers: Fix CrashLoopBackOff of manager pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 COPY webhook/ webhook/
 
 # Build
-RUN make go-build
+RUN CGO_ENABLED=0 make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Fix Error: "standard_init_linux.go:219: exec user process caused: no
such file or directory".

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>