### PR TITLE
Add bundle dependency

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- type: olm.package
+  value:
+    packageName: ocs-operator
+    version: ">=4.9.0 <4.10.0"

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -44,9 +44,12 @@ CATALOG_IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(CATALOG_IMAGE_NAME):$(I
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
+
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
+OCS_BUNDLE_IMG ?= quay.io/ocs-dev/ocs-operator-bundle:latest
+IBM_BUNDLE_IMG ?= docker.io/ibmcom/ibm-storage-odf-operator-bundle:0.2.0
+BUNDLE_IMGS ?= $(shell echo $(BUNDLE_IMG) $(OCS_BUNDLE_IMG) $(IBM_BUNDLE_IMG) | sed "s/ /,/g")
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)


### PR DESCRIPTION
Add "ocs-operator" as a dependency of odf

Add "ocs-operator" and "ibm-storage-odf-operator" bundle images to build
within our catalog image.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>