### PR TITLE
controllers: use env var instead of hardcoded values

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 Red Hat OpenShift Data Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"os"
+)
+
+var (
+	DefaultValMap = map[string]string{
+		"OCS_CSV_NAME":                             "ocs-operator.v4.9.0",
+		"IBM_SUBSCRIPTION_NAME":                    "ibm-storage-odf-operator",
+		"IBM_SUBSCRIPTION_PACKAGE":                 "ibm-storage-odf-operator",
+		"IBM_SUBSCRIPTION_CHANNEL":                 "stable-v1",
+		"IBM_SUBSCRIPTION_STARTINGCSV":             "ibm-storage-odf-operator.v0.2.0",
+		"IBM_SUBSCRIPTION_CATALOGSOURCE":           "odf-catalogsource",
+		"IBM_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE": "openshift-marketplace",
+	}
+
+	OcsCsvName                            = GetEnvOrDefault("OCS_CSV_NAME")
+	IbmSubscriptionName                   = GetEnvOrDefault("IBM_SUBSCRIPTION_NAME")
+	IbmSubscriptionPackage                = GetEnvOrDefault("IBM_SUBSCRIPTION_PACKAGE")
+	IbmSubscriptionChannel                = GetEnvOrDefault("IBM_SUBSCRIPTION_CHANNEL")
+	IbmSubscriptionStartingCSV            = GetEnvOrDefault("IBM_SUBSCRIPTION_STARTINGCSV")
+	IbmSubscriptionCatalogSource          = GetEnvOrDefault("IBM_SUBSCRIPTION_CATALOGSOURCE")
+	IbmSubscriptionCatalogSourceNamespace = GetEnvOrDefault("IBM_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE")
+)
+
+func GetEnvOrDefault(env string) string {
+	if val := os.Getenv(env); val != "" {
+		return val
+	}
+
+	return DefaultValMap[env]
+}

--- a/controllers/flashsystemcluster.go
+++ b/controllers/flashsystemcluster.go
@@ -23,15 +23,6 @@ import (
 	odfv1alpha1 "github.com/red-hat-data-services/odf-operator/api/v1alpha1"
 )
 
-const (
-	IbmSubscriptionName                   = "ibm-storage-odf-operator"
-	IbmSubscriptionPackage                = "ibm-storage-odf-operator"
-	IbmSubscriptionChannel                = "stable-v1"
-	IbmSubscriptionStartingCSV            = "ibm-storage-odf-operator.v0.2.0"
-	IbmSubscriptionCatalogSource          = "odf-catalogsource"
-	IbmSubscriptionCatalogSourceNamespace = "openshift-marketplace"
-)
-
 // GetFlashSystemClusterSubscription return subscription for FlashSystemCluster
 func GetFlashSystemClusterSubscription(instance *odfv1alpha1.StorageSystem) *operatorv1alpha1.Subscription {
 

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -28,10 +28,6 @@ import (
 	odfv1alpha1 "github.com/red-hat-data-services/odf-operator/api/v1alpha1"
 )
 
-const (
-	OcsCsvName = "ocs-operator.v4.9.0"
-)
-
 func FilterSubscriptionWithPackage(subs *operatorv1alpha1.SubscriptionList, pkg string) *operatorv1alpha1.Subscription {
 
 	for _, s := range subs.Items {


### PR DESCRIPTION
remove the constant values and define a map of default values. Which
will be used only if env var is not set/defined.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>