### PR TITLE
action: Add action to wait for dependent PR to be merged

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,12 @@
+name: github
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1


### PR DESCRIPTION
We can block the PR from merging and wait for its dependencies to be merged via adding `Depends on #<>`

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>