### PR TITLE
controllers: Append "-storagesystem" while creating storagesystem

### DIFF
--- a/controllers/storagecluster_controller.go
+++ b/controllers/storagecluster_controller.go
@@ -80,7 +80,7 @@ func (r *StorageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		storageSystem = &odfv1alpha1.StorageSystem{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      instance.Name,
+				Name:      instance.Name + "-storagesystem",
 				Namespace: instance.Namespace,
 			},
 			Spec: odfv1alpha1.StorageSystemSpec{

--- a/controllers/storagecluster_controller_test.go
+++ b/controllers/storagecluster_controller_test.go
@@ -70,9 +70,11 @@ func TestReconcile(t *testing.T) {
 		assert.NoError(t, err)
 
 		if tc.AlreadyHasStorageSystem {
-			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "fake-storage-system", Namespace: "fake-namespace"}, fakeStorageSystem)
+			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
+				Name: "fake-storage-system", Namespace: "fake-namespace"}, fakeStorageSystem)
 		} else {
-			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: fakeStorageCluster.Name, Namespace: fakeStorageCluster.Namespace}, fakeStorageSystem)
+			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
+				Name: fakeStorageCluster.Name + "-storagesystem", Namespace: fakeStorageCluster.Namespace}, fakeStorageSystem)
 		}
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Append "-storagesystem" in the name of storagesystem while creating
storagesystem for the storagecluster.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>