### PR TITLE
Bug 1994261: Add required permissions for console to initialize properly

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -41,6 +41,18 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -50,6 +62,24 @@ spec:
           - list
           - update
           - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleplugins
+          verbs:
+          - '*'
         - apiGroups:
           - console.openshift.io
           resources:
@@ -170,55 +200,6 @@ spec:
           - create
         serviceAccountName: odf-operator-controller-manager
       deployments:
-      - name: odf-console
-        spec:
-          selector:
-            matchLabels:
-              app: odf-console
-          strategy: {}
-          template:
-            metadata:
-              labels:
-                app: odf-console
-            spec:
-              containers:
-              - args:
-                - --ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key
-                image: badhikar/odf-console:latest
-                name: odf-console
-                ports:
-                - containerPort: 9001
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 100m
-                    memory: 512Mi
-                volumeMounts:
-                - mountPath: /var/serving-cert
-                  name: odf-console-serving-cert
-                  readOnly: true
-              - args:
-                - --ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key
-                image: ibmcom/ibm-storage-odf-plugin:0.2.0
-                name: ibm-console
-                ports:
-                - containerPort: 9002
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 100m
-                    memory: 512Mi
-                volumeMounts:
-                - mountPath: /var/serving-cert
-                  name: ibm-console-serving-cert
-                  readOnly: true
-              volumes:
-              - name: odf-console-serving-cert
-                secret:
-                  secretName: odf-console-serving-cert
-              - name: ibm-console-serving-cert
-                secret:
-                  secretName: ibm-console-serving-cert
       - name: odf-operator-controller-manager
         spec:
           replicas: 1
@@ -248,7 +229,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --odf-console-port=9001
-                - --odf-console-port=9002
+                - --ibm-console-port=9003
                 command:
                 - /manager
                 env:
@@ -314,6 +295,55 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: odf-operator-controller-manager
               terminationGracePeriodSeconds: 10
+      - name: odf-console
+        spec:
+          selector:
+            matchLabels:
+              app: odf-console
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: odf-console
+            spec:
+              containers:
+              - args:
+                - --ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key
+                image: badhikar/odf-console:latest
+                name: odf-console
+                ports:
+                - containerPort: 9001
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /var/serving-cert
+                  name: odf-console-serving-cert
+                  readOnly: true
+              - args:
+                - --ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key
+                image: ibmcom/ibm-storage-odf-plugin:0.2.0
+                name: ibm-console
+                ports:
+                - containerPort: 9003
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /var/serving-cert
+                  name: ibm-console-serving-cert
+                  readOnly: true
+              volumes:
+              - name: odf-console-serving-cert
+                secret:
+                  secretName: odf-console-serving-cert
+              - name: ibm-console-serving-cert
+                secret:
+                  secretName: ibm-console-serving-cert
       permissions:
       - rules:
         - apiGroups:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -34,7 +34,7 @@ spec:
               cpu: "100m"
               memory: "512Mi"
           ports:
-            - containerPort: 9002
+            - containerPort: 9003
               protocol: TCP
           args:
             - "--ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -25,4 +25,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--odf-console-port=9001"
-        - "--odf-console-port=9003"
+        - "--ibm-console-port=9003"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -16,6 +28,24 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - '*'
 - apiGroups:
   - console.openshift.io
   resources:

--- a/console/console.go
+++ b/console/console.go
@@ -67,10 +67,10 @@ func GetService(serviceName string, port int, owner metav1.ObjectMeta) apiv1.Ser
 	}
 }
 
-func GetConsolePluginCR(displayName string, consolePort int, serviceName string, owner metav1.ObjectMeta) consolev1alpha1.ConsolePlugin {
+func GetConsolePluginCR(pluginName string, displayName string, consolePort int, serviceName string, owner metav1.ObjectMeta) consolev1alpha1.ConsolePlugin {
 	return consolev1alpha1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "odf-console",
+			Name: pluginName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "apps/v1",
@@ -91,6 +91,10 @@ func GetConsolePluginCR(displayName string, consolePort int, serviceName string,
 	}
 }
 
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=*
+
 func InitConsole(client client.Client, odfPort int, ibmPort int) error {
 	deployment := appsv1.Deployment{}
 	if err := client.Get(context.TODO(), types.NamespacedName{
@@ -105,7 +109,7 @@ func InitConsole(client client.Client, odfPort int, ibmPort int) error {
 		return err
 	}
 	// Create core ODF Plugin
-	odfConsolePlugin := GetConsolePluginCR("ODF Plugin", odfPort, odfService.ObjectMeta.Name, deployment.ObjectMeta)
+	odfConsolePlugin := GetConsolePluginCR("odf-console", "ODF Plugin", odfPort, odfService.ObjectMeta.Name, deployment.ObjectMeta)
 	if err := client.Create(context.TODO(), &odfConsolePlugin); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
@@ -115,7 +119,7 @@ func InitConsole(client client.Client, odfPort int, ibmPort int) error {
 		return err
 	}
 	// Create IBM Console Plugin
-	ibmConsolePlugin := GetConsolePluginCR("IBM Plugin", ibmPort, ibmService.ObjectMeta.Name, deployment.ObjectMeta)
+	ibmConsolePlugin := GetConsolePluginCR("ibm-console", "IBM Plugin", ibmPort, ibmService.ObjectMeta.Name, deployment.ObjectMeta)
 	if err := client.Create(context.TODO(), &ibmConsolePlugin); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}


### PR DESCRIPTION
CRUD permissions for deployment, services and consoleplugins is required for ODF Console to function properly.
