### PR TITLE
bundle: create a namespace automatically via UI if not one present

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -18,6 +18,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: odf-operator.v0.0.1

--- a/config/manifests/bases/odf-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operatorframework.io/suggested-namespace: openshift-storage
   name: odf-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
create a openshift-storage namespace via UI automatically while
installing the operator.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>