### PR TITLE
bundle: Add annotation to indentify ODF contains a dynamic plugin.

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Storage
+    console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.

--- a/config/manifests/bases/odf-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Deep Insights
     categories: Storage
+    console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.


### PR DESCRIPTION
- Enables a checkbox in the UI that would allow users to enable the UI plugin.

Since ODF is part of `redhat-operators` catalog this checkbox will be selected by default. Not adding IBM as we don't want to enable IBM UI by default. 

/assign @iamniting @jarrpa 
