### PR TITLE
bundle: Update CSV to use official console image and add console annotation

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Storage
+    console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.

--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -323,7 +323,7 @@ spec:
               containers:
               - args:
                 - --ssl --cert=/var/serving-cert/tls.crt --key=/var/serving-cert/tls.key
-                image: badhikar/odf-console:latest
+                image: quay.io/ocs-dev/odf-console:latest
                 name: odf-console
                 ports:
                 - containerPort: 9001

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: odf-console
-          image: badhikar/odf-console:latest
+          image: quay.io/ocs-dev/odf-console:latest
           resources:
             limits:
               cpu: "100m"

--- a/config/manifests/bases/odf-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Deep Insights
     categories: Storage
+    console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.


### PR DESCRIPTION
- Use official images for ODF Console from quay repository. 
- Update CSV annotations to identify ODF Operator as a dynamic plugin carrier. 