### PR TITLE
controllers: Add and update conditions in storageSystem controller

### DIFF
--- a/api/v1alpha1/storagesystem_types.go
+++ b/api/v1alpha1/storagesystem_types.go
@@ -30,8 +30,14 @@ import (
 type StorageKind string
 
 const (
-	// ConditionResourcePresent communicates the status of underlying resource
-	ConditionResourcePresent conditionsv1.ConditionType = "ResourcePresent"
+	//ConditionStorageSystemInvalid communicates if storagesystem CR is invalid
+	ConditionStorageSystemInvalid conditionsv1.ConditionType = "StorageSystemInvalid"
+
+	// ConditionVendorCsvReady communicates if CSV is ready
+	ConditionVendorCsvReady conditionsv1.ConditionType = "VendorCsvReady"
+
+	// ConditionVendorSystemPresent communicates if backend storage CR is present in the cluster
+	ConditionVendorSystemPresent conditionsv1.ConditionType = "VendorSystemPresent"
 )
 
 // StorageSystemSpec defines the desired state of StorageSystem

--- a/api/v1alpha1/storagesystem_types.go
+++ b/api/v1alpha1/storagesystem_types.go
@@ -56,7 +56,7 @@ type StorageSystemSpec struct {
 type StorageSystemStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Conditions describes the state of the StorageCluster resource.
+	// Conditions describes the state of the StorageSystem resource.
 	// +optional
 	Conditions []conditionsv1.Condition `json:"conditions,omitempty"`
 }

--- a/api/v1alpha1/storagesystem_types.go
+++ b/api/v1alpha1/storagesystem_types.go
@@ -34,20 +34,6 @@ const (
 	ConditionResourcePresent conditionsv1.ConditionType = "ResourcePresent"
 )
 
-const (
-	// PhaseDeleting represents the Deleting state of storagesystem
-	PhaseDeleting = "Deleting"
-
-	// PhaseError represents the Error state of storagesystem
-	PhaseError = "Error"
-
-	// PhaseProgressing represents the Progressing state of storagesystem
-	PhaseProgressing = "Progressing"
-
-	// PhaseReady represents the Ready state of storagesystem
-	PhaseReady = "Ready"
-)
-
 // StorageSystemSpec defines the desired state of StorageSystem
 type StorageSystemSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
@@ -70,11 +56,6 @@ type StorageSystemSpec struct {
 type StorageSystemStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Phase describes the Phase of StorageSystem
-	// This is used by OLM UI to provide status information
-	// to the user
-	Phase string `json:"phase,omitempty"`
-
 	// Conditions describes the state of the StorageCluster resource.
 	// +optional
 	Conditions []conditionsv1.Condition `json:"conditions,omitempty"`
@@ -85,7 +66,6 @@ type StorageSystemStatus struct {
 //+kubebuilder:resource:shortName=storsys
 //+kubebuilder:printcolumn:JSONPath=".spec.kind",name=storage-system-kind,type=string
 //+kubebuilder:printcolumn:JSONPath=".spec.name",name=storage-system-name,type=string
-//+kubebuilder:printcolumn:JSONPath=".status.phase",name=phase,type=string
 
 // StorageSystem is the Schema for the storagesystems API
 type StorageSystem struct {

--- a/bundle/manifests/odf.openshift.io_storagesystems.yaml
+++ b/bundle/manifests/odf.openshift.io_storagesystems.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .spec.name
       name: storage-system-name
       type: string
-    - jsonPath: .status.phase
-      name: phase
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -95,10 +92,6 @@ spec:
                   - type
                   type: object
                 type: array
-              phase:
-                description: Phase describes the Phase of StorageSystem This is used
-                  by OLM UI to provide status information to the user
-                type: string
             type: object
         type: object
     served: true

--- a/bundle/manifests/odf.openshift.io_storagesystems.yaml
+++ b/bundle/manifests/odf.openshift.io_storagesystems.yaml
@@ -65,8 +65,7 @@ spec:
             description: StorageSystemStatus defines the observed state of StorageSystem
             properties:
               conditions:
-                description: Conditions describes the state of the StorageCluster
-                  resource.
+                description: Conditions describes the state of the StorageSystem resource.
                 items:
                   description: Condition represents the state of the operator's reconciliation
                     functionality.

--- a/config/crd/bases/odf.openshift.io_storagesystems.yaml
+++ b/config/crd/bases/odf.openshift.io_storagesystems.yaml
@@ -67,8 +67,7 @@ spec:
             description: StorageSystemStatus defines the observed state of StorageSystem
             properties:
               conditions:
-                description: Conditions describes the state of the StorageCluster
-                  resource.
+                description: Conditions describes the state of the StorageSystem resource.
                 items:
                   description: Condition represents the state of the operator's reconciliation
                     functionality.

--- a/config/crd/bases/odf.openshift.io_storagesystems.yaml
+++ b/config/crd/bases/odf.openshift.io_storagesystems.yaml
@@ -25,9 +25,6 @@ spec:
     - jsonPath: .spec.name
       name: storage-system-name
       type: string
-    - jsonPath: .status.phase
-      name: phase
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -97,10 +94,6 @@ spec:
                   - type
                   type: object
                 type: array
-              phase:
-                description: Phase describes the Phase of StorageSystem This is used
-                  by OLM UI to provide status information to the user
-                type: string
             type: object
         type: object
     served: true

--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -111,8 +111,6 @@ func (r *StorageSystemReconciler) reconcile(instance *odfv1alpha1.StorageSystem,
 
 	var err error
 
-	instance.Status.Phase = odfv1alpha1.PhaseProgressing
-
 	// add/remove finalizer
 	if instance.GetDeletionTimestamp().IsZero() {
 		if !util.FindInSlice(instance.GetFinalizers(), storageSystemFinalizer) {
@@ -125,7 +123,6 @@ func (r *StorageSystemReconciler) reconcile(instance *odfv1alpha1.StorageSystem,
 		}
 	} else {
 		// deletion phase
-		instance.Status.Phase = odfv1alpha1.PhaseDeleting
 
 		if util.FindInSlice(instance.GetFinalizers(), storageSystemFinalizer) {
 
@@ -165,15 +162,12 @@ func (r *StorageSystemReconciler) reconcile(instance *odfv1alpha1.StorageSystem,
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	instance.Status.Phase = odfv1alpha1.PhaseReady
-
 	return ctrl.Result{}, nil
 }
 
 func (r *StorageSystemReconciler) validateStorageSystemSpec(instance *odfv1alpha1.StorageSystem, logger logr.Logger) error {
 
 	if instance.Spec.Kind != VendorStorageCluster() && instance.Spec.Kind != VendorFlashSystemCluster() {
-		instance.Status.Phase = odfv1alpha1.PhaseError
 		return fmt.Errorf("unsupported kind %s", instance.Spec.Kind)
 	}
 

--- a/controllers/vendor_test.go
+++ b/controllers/vendor_test.go
@@ -28,7 +28,7 @@ import (
 	odfv1alpha1 "github.com/red-hat-data-services/odf-operator/api/v1alpha1"
 )
 
-func TestSetConditionResourcePresent(t *testing.T) {
+func TestIsVendorSystemPresent(t *testing.T) {
 
 	testCases := []struct {
 		label             string
@@ -40,13 +40,11 @@ func TestSetConditionResourcePresent(t *testing.T) {
 		{
 			label:             "ensure ResourcePresent condition is true",
 			hasBackEndStorage: true,
-			expectedRequeue:   false,
 			expectedError:     false,
 		},
 		{
 			label:             "ensure ResourcePresent condition is false",
 			hasBackEndStorage: false,
-			expectedRequeue:   true,
 			expectedError:     true,
 		},
 	}
@@ -69,12 +67,11 @@ func TestSetConditionResourcePresent(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		requeue, err := fakeReconciler.setConditionResourcePresent(fakeStorageSystem, fakeReconciler.Log)
-		assert.Equal(t, tc.expectedRequeue, requeue)
+		err = fakeReconciler.isVendorSystemPresent(fakeStorageSystem, fakeReconciler.Log)
 
 		assert.Equal(t, tc.hasBackEndStorage,
 			conditionsv1.IsStatusConditionTrue(
-				fakeStorageSystem.Status.Conditions, odfv1alpha1.ConditionResourcePresent))
+				fakeStorageSystem.Status.Conditions, odfv1alpha1.ConditionVendorSystemPresent))
 
 		if tc.expectedError {
 			assert.Error(t, err)


### PR DESCRIPTION
Mark storage system as ready if csv is ready, either underlying storage
CR is present or not, so that UI can create a IBM flashsystem based on
its phase.

Without this change UI will never be able to create a IBM flashsystem.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>