### PR TITLE
Add GH action to copy noobaa images to quay/ocs-dev

### DIFF
--- a/.github/workflows/mirror-noobaa-upstream-images.yaml
+++ b/.github/workflows/mirror-noobaa-upstream-images.yaml
@@ -1,0 +1,22 @@
+name: mirror-noobaa-upstream-images
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  mirror-noobaa-upstream-images:
+    runs-on: ubuntu-latest
+    if: github.repository == 'red-hat-storage/odf-operator' && github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: log into quay
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+    - name: mirror images
+      run: hack/mirror-noobaa-images.sh

--- a/hack/mirror-noobaa-images.sh
+++ b/hack/mirror-noobaa-images.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+shopt -s inherit_errexit
+set -x
+
+# Script will mirror the latest NooBaa upstream master images to quay.io/ocs-dev with a 'master' tag
+# that can be used by CI.
+
+# Requirements:
+#   - cli: jq docker
+#   - must be logged into quay to push to quay.io/ocs-dev
+
+
+function latest_master_tag () {
+    local repo="$1"
+
+    URL=https://registry.hub.docker.com/v2/repositories/${repo}/tags/
+    # noobaa images are tagged as "master-<date>" (e.g., master-20210824)
+    tags="$(curl -s -S "$URL" | jq --raw-output '.results[].name')"
+    master_tags="$(echo "${tags}" | grep --extended-regexp "^master-[[:digit:]]{8}$")"
+    latest_tag="$(echo "${master_tags}" | sort --numeric-sort --reverse | head -n1 )"
+    echo "${latest_tag}"
+}
+
+for image in noobaa-core noobaa-operator; do
+    repo="noobaa/${image}"
+    latest="$(latest_master_tag "${repo}")"
+    latest_image="${repo}:${latest}"
+
+    docker pull "${latest_image}"
+
+    quay_latest="quay.io/ocs-dev/${image}:${latest}"
+    quay_master="quay.io/ocs-dev/${image}:master"
+    docker tag "${latest_image}" "${quay_latest}"
+    docker tag "${latest_image}" "${quay_master}"
+
+    docker push "${quay_latest}"
+    docker push "${quay_master}"
+done


### PR DESCRIPTION
Add a GitHub Action to copy the latest noobaa image to quay.io/ocs-dev
for both noobaa-core and noobaa-operator images. When the latest image
is copied, it is also tagged as "master". The master image can be used
in CI to automatically get the latest NooBaa upstream master image.

Run the action every hour. This will make sure that the latest NooBaa
image is copied relatively quickly no matter when it is released, and it
will be retried the next hour if there is a network outage or other
failure. If there are no updates to the image, the action should
complete in 30 seconds or less.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>