### PR TITLE
controllers: fix status of StorageSystemInvalid

### DIFF
--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -180,6 +180,8 @@ func (r *StorageSystemReconciler) validateStorageSystemSpec(instance *odfv1alpha
 		r.Recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, EventReasonValidationFailed, err.Error())
 		SetStorageSystemInvalidConditions(&instance.Status.Conditions, "NotValid", err.Error())
 		return err
+	} else {
+		SetStorageSystemInvalidCondition(&instance.Status.Conditions, corev1.ConditionFalse, "Valid", "StorageSystem CR is valid")
 	}
 
 	return nil


### PR DESCRIPTION
Fix the bug where the status of StorageSystemInvalid condition is
always in the Unknown state.

```
  - lastHeartbeatTime: "2021-09-02T06:41:10Z"
    lastTransitionTime: "2021-09-02T06:41:10Z"
    message: Initializing StorageSystem
    reason: Init
    status: Unknown

```

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>