### PR TITLE
controllers: remove setup for StorageCluster controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,16 +124,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	storageClusterReconciler := &controllers.StorageClusterReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: controllers.NewEventReporter(mgr.GetEventRecorderFor("StorageCluster controller")),
-	}
-	if err = storageClusterReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "StorageCluster")
-		os.Exit(1)
-	}
-
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Managing the dependent Subscriptions introduced a paradox where we are
trying to watch for a resource type that doesn't exist yet... and
controller-runtime does not like this. This patch temporarily removes
the setup of the StorageCluster controller to work around the CLBO, for
testing purposes, a more appropriate resolution is being developed.

For this PR, I have verified both installation of ODF 4.8 and upgrade from OCS 4.8 to ODF 4.9 using the following resources: https://github.com/jarrpa/ocs-operator/tree/jarrpa-dev-master/upgrade-testing

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>