### PR TITLE
console: Remove ConsolePlugin during operator uninstallation

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,4 +146,9 @@ func main() {
 		setupLog.Error(err, "problem removing subscriptions")
 		os.Exit(1)
 	}
+
+	setupLog.Info("removing console plugin CR")
+	if err := console.RemoveConsole(mgr.GetClient()); err != nil {
+		setupLog.Error(err, "problem removing console plugin")
+	}
 }


### PR DESCRIPTION
ConsolePlugin is a cluster scoped CRD thus the owner needs to be a cluster scoped resource.
ConsolePlugin CR gets removed when StorageSystem CRD is removed.

Signed-off-by: bipuladh <badhikar@redhat.com>