### PR TITLE
[HACK] pre-create OCS Subscriptions in StorageSystemReconciler.SetupWithManager()

### DIFF
--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -155,7 +155,7 @@ func (r *StorageSystemReconciler) reconcile(instance *odfv1alpha1.StorageSystem,
 		return ctrl.Result{}, err
 	}
 
-	err = r.ensureSubscription(instance, logger)
+	err = r.ensureSubscription(instance, true, logger)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -63,7 +63,7 @@ func TestEnsureSubscription(t *testing.T) {
 				}
 			}
 
-			err = fakeReconciler.ensureSubscription(fakeStorageSystem, fakeReconciler.Log)
+			err = fakeReconciler.ensureSubscription(fakeStorageSystem, true, fakeReconciler.Log)
 			assert.NoError(t, err)
 
 			for _, expectedSubscription := range subs {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	storageClusterReconciler := &controllers.StorageClusterReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: controllers.NewEventReporter(mgr.GetEventRecorderFor("StorageCluster controller")),
+	}
+	if err = storageClusterReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "StorageCluster")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
This PR pre-creates the OCS Subscription so as to re-enable the StorageClusterReconciler that was giving us CLBO after #99 was merged too hastily. The bug itself was that controller-runtime was expecting the StorageCluster CRD to exist *before* the controller manager is started, hence we are now creating the Subscription in `StorageSystemReconciler.SetupWithManager()`.

I really really REALLY REALLY don't like this, but I'm going through with it as a workaround for the installation and upgrade blockers in release-4.9. We'll need to take time to carefully consider a proper fix for this.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>