### PR TITLE
makefile: Do not run tests as part of Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ COPY config/ config/
 COPY metrics/ metrics/
 COPY console/ console/
 
-# Run tests and linting
-RUN make test
-
 # Build
 RUN make go-build
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ go-build: ## Run go build against code.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-build: ## Build docker image with the manager.
+docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
It always downloads the binaries required for tests which makes it
slower.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>