### PR TITLE
makefile: remove vendor-update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-vendor-update: ## Run go mod vendor against code.
-	go mod vendor
+godeps-update:
+	go mod tidy && go mod vendor
 
-test: manifests generate fmt vet vendor-update ## Run tests.
+test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
@@ -90,7 +90,7 @@ go-build: ## Run go build against code.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-build: vendor-update ## Build docker image with the manager.
+docker-build: godeps-update ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
running `go mod vendor` while running tests in the container downloads
the all deps again eventhoug they are already installed. Moreover go
already do these checks and verify go.mod with the vendor/modules.txt.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

The example runs show this target is not required:

https://github.com/iamniting/odf-operator/runs/4035819892?check_suite_focus=true
https://github.com/iamniting/odf-operator/runs/4035819310?check_suite_focus=true

It does save the unnecessary download twice.