### PR TITLE
controllers: Approve manual installplans

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -278,6 +278,24 @@ spec:
         - apiGroups:
           - operators.coreos.com
           resources:
+          - clusterserviceversions/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - installplans
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
           - subscriptions
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -175,6 +175,24 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - clusterserviceversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - subscriptions
   verbs:
   - create


### PR DESCRIPTION
Manual strategy is kind of pain for managed operators for a user in the
UI as User can not approve them very easily. Handling them via the
operators itself will be a really useful for the one click smooth
upgrade process.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2016324

