### PR TITLE
console: Fix basepath for odf-console deployment

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const MAIN_BASE_PATH = ""
-const COMPATIBILITY_BASE_PATH = "compatibility"
+const MAIN_BASE_PATH = "/"
+const COMPATIBILITY_BASE_PATH = "/compatibility/"
 
 func GetDeployment(namespace string) *appsv1.Deployment {
 	return &appsv1.Deployment{


### PR DESCRIPTION
There were a couple of changes introduced in OCP 4.10 which caused the
dynamic plugin to break. 


Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>