### PR TITLE
controllers: add StorageClass encryption page to ODF QuickStart guide

### DIFF
--- a/controllers/quickstart_constants.go
+++ b/controllers/quickstart_constants.go
@@ -238,6 +238,54 @@ spec:
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: You have successfully created BucketClass
+        failed: Try the steps again. 
+    - title: Encrypt your StorageClass
+      description: |-
+
+          StorageClass encryption enables you to provide individual keys to each of your StorageClusters.
+
+
+          You can create an encrypted StorageClass while configuring your StorageCluster, or when creating a new StorageClass.
+
+
+          **To create an encrypted StorageClass while setting up your cluster:**
+
+          1. In the navigation menu, select [Operators]{{highlight qs-nav-operators}} and select **Installed Operators**, then select **Create StorageSystem**.
+
+          2. In the creation wizard, go to **Security and network** step.
+
+          3. Check the **StorageClass encryption** box.
+
+          4. Select your **Key management service provider**.
+
+          5. Provide your connection details.
+
+
+          **To create a new encrypted StorageClass:**
+
+          1. In the navigation menu, select [Storage]{{highlight qs-nav-storage}} and select **StorageClasses**, then select **Create StorageClass**.
+
+          2. In the **Provisioner** field, select **openshift-storage.rbd.csi.ceph.com**.
+
+          3. Check the **Enable Encryption** box.
+
+          4. Select your **Key management service provider**.
+
+          5. Provide your connection details.
+      review:
+        instructions: |-
+          ####  To verify that the StorageClass is encrypted:
+          1. Go to **Storage > StorageClasses**.
+          If you encrypted the StorageClass while setting up your cluster, check that a new **ocs-storagecluster-ceph-rbd-encrypted** StorageClass is created.
+
+          2. Select the newly created StorageClass and select the **YAML** tab.
+
+          Does the value of the parameter **encrypted** equal to **true**?
+
+          Is the value of the parameter **encryptionKMSID** equal to the KMS connection's service name?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You have successfully encrypted StorageClass
         failed: Try the steps again.
 
   conclusion: You're ready to go! Now you can customize your StorageSystems in OpenShift Data Foundation.


### PR DESCRIPTION
adds one more step "Encrypt your StorageClass" to "Configure and manage OpenShift Data Foundation" QuickStart guide.
![Screenshot from 2021-11-22 19-54-38](https://user-images.githubusercontent.com/39404641/142878689-739d3688-b0cf-48d1-994b-8d0c858e5da3.png)
![Screenshot from 2021-11-22 19-54-51](https://user-images.githubusercontent.com/39404641/142878710-2d33c9ed-992e-46ce-828f-3658ebe7978b.png)


Epic URL: https://issues.redhat.com/browse/RHSTOR-1950
Signed-off-by: sanjalkatiyar <sanjaldhir@gmail.com>