### PR TITLE
Increase max controller memory to 300Mi

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -402,7 +402,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 100Mi
+                    memory: 300Mi
                   requests:
                     cpu: 200m
                     memory: 100Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,7 +51,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 200m
             memory: 100Mi


### PR DESCRIPTION
In my test environment the controlelr uses around 200MiB of memory. To
avoid getting killed we now increase the memory to 300MiB.

<img src="https://user-images.githubusercontent.com/695473/146542703-bf552345-6790-468c-a341-adac133ca40d.png" height=450px></img>
