### PR TITLE
controllers: reconcile noobaa subscription before ocs-operator

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -289,7 +289,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	return []*operatorv1alpha1.Subscription{ocsSubscription, noobaaSubscription}
+	return []*operatorv1alpha1.Subscription{noobaaSubscription, ocsSubscription}
 }
 
 // GetFlashSystemClusterSubscription return subscription for FlashSystemCluster


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2034098