### PR TITLE
console: update compatibility support matrix for 4.10

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -84,7 +84,7 @@ func GetConsolePluginCR(consolePort int, basePath string, serviceNamespace strin
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.10") {
+	if strings.Contains(clusterVersion, "4.11") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
- ODF 4.10 supports OCP 4.10 and 4.11.
- Updating compatibility build to be activated with OCP 4.11. 

Signed-off-by: Bipul Adhikari <badhikar@redhat.com>