### PR TITLE
controllers: change controller ref to owner ref of the vendor system

### DIFF
--- a/controllers/vendors.go
+++ b/controllers/vendors.go
@@ -74,7 +74,7 @@ func (r *StorageSystemReconciler) isVendorSystemPresent(instance *odfv1alpha1.St
 		logger.Info("Vendor system found", "Name", instance.Spec.Name)
 		SetVendorSystemPresentCondition(&instance.Status.Conditions, corev1.ConditionTrue, "Found", "")
 		_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, vendorSystem, func() error {
-			return controllerutil.SetControllerReference(instance, vendorSystem, r.Scheme)
+			return controllerutil.SetOwnerReference(instance, vendorSystem, r.Scheme)
 		})
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err


### PR DESCRIPTION
We are using the controller ref to show the vendor CR in the OCP UI and can also use the owner ref for the same.
controller ref is required by the managed services as storageCluster is created by them in the manages services.

changing the controller ref to owner ref will solve the managed services problem.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2044447

Signed-off-by: bindrad <dbindra@redhat.com>