### PR TITLE
action: Push bundle image to the local registry while testing catalog

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -57,4 +57,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build catalog docker image
-        run: make catalog-build
+        env:
+          IMAGE_REGISTRY: localhost:5000
+        run: |
+          docker run -d -p 5000:5000 --name registry registry:2
+          make bundle-build bundle-push catalog-build


### PR DESCRIPTION
catalog build pulls the bundle images before creating and catalog image
and it does not make sense to download the existing odf-operator-bundle
image from the quay. instead push the current odf-operator-bundle to
local registry and pull it from there.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>