### PR TITLE
Use a unique label for monitoring resources

### DIFF
--- a/bundle/manifests/odf-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/odf-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
   name: odf-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
@@ -14,4 +14,4 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: odf-operator

--- a/bundle/manifests/odf-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/odf-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
   name: odf-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -11,6 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -356,12 +356,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              app.kubernetes.io/name: odf-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                app.kubernetes.io/name: odf-operator
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: odf-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: odf-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -16,4 +16,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: odf-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -9,4 +9,4 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: odf-operator


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2043034

Issue
=====
Both csi-addon operator and odf-operator are using the default label and label-selector provided by operator-sdk - "control-plane: controller-manager" for its services and deployments.
This is allowing deployments, services and service monitors of each operator to select the pods ans services of other operator.
One critical impact of this is in UI monitoring where odf metrics monitor is picking up csiaddon service and hence showing an extra storage system. This is breaking the prometheus query and hence missing storage system on UI.

Fix
===
Use a unique label selector in odf-operator to avoid conflicts.

Before:
![Screenshot from 2022-02-23 21-28-06](https://user-images.githubusercontent.com/25664409/155357081-43ce1d67-a9fc-458d-a077-8a866cd046e4.png)


After:
![Screenshot from 2022-02-23 19-44-12](https://user-images.githubusercontent.com/25664409/155357107-c3206357-1903-4b08-b29a-7e71231da5d1.png)
