### PR TITLE
controllers: add ocs toleration to csi-addons subscription

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"go.uber.org/multierr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -273,6 +274,16 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 			Channel:                CSIAddonsSubscriptionChannel,
 			StartingCSV:            CSIAddonsSubscriptionStartingCSV,
 			InstallPlanApproval:    operatorv1alpha1.ApprovalAutomatic,
+			Config: &operatorv1alpha1.SubscriptionConfig{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node.ocs.openshift.io/storage",
+						Operator: "Equal",
+						Value:    "true",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This commit adds the following tolerationt to
csi-addons subscription so it is applied to
all the pods it creates.
```
      - effect: NoSchedule
        key: node.ocs.openshift.io/storage
        operator: Equal
        value: "true"
```

Currently all the pods related to storage is expected to have the
above toleration to be able to tolerate taints on node dedicated for storage(refer [1]).
The other operators have this in their manager.yaml files. 
By adding this to csiaddons subscription(which will pass it onto any pods created
by it, refer [2}), we can avoid having it in upstream code.

Signed-off-by: Rakshith R <rar@redhat.com>


[1] https://bugzilla.redhat.com/show_bug.cgi?id=2059105
[2] https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#tolerations