### PR TITLE
controllers: stop adding annotation to the storagecluster

### DIFF
--- a/controllers/storagecluster_controller.go
+++ b/controllers/storagecluster_controller.go
@@ -106,14 +106,6 @@ func (r *StorageClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		logger.Info("StorageSystem is already present for the StorageCluster.", "StorageSystem", storageSystem.Name)
 	}
 
-	// update Annotation for the storageCluster
-	metav1.SetMetaDataAnnotation(&instance.ObjectMeta, string(HasStorageSystemAnnotation), storageSystem.Name)
-	err = r.Client.Update(context.TODO(), instance)
-	if err != nil {
-		logger.Error(err, "Failed to update the StorageCluster Annotation.")
-		return ctrl.Result{}, err
-	}
-
 	return ctrl.Result{}, nil
 }
 
@@ -131,32 +123,18 @@ func filterStorageSystem(storageSystemList *odfv1alpha1.StorageSystemList, stora
 // SetupWithManager sets up the controller with the Manager.
 func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
-	predicateFunc := func(obj runtime.Object) bool {
-		instance, ok := obj.(*ocsv1.StorageCluster)
-		if !ok {
-			return false
-		}
-
-		// ignore if Annotation is present
-		if _, ok = instance.ObjectMeta.Annotations[HasStorageSystemAnnotation]; ok {
-			return false
-		}
-
-		return true
-	}
-
 	storageClusterPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return predicateFunc(e.Object)
+			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return predicateFunc(e.ObjectNew)
+			return false
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return predicateFunc(e.Object)
+			return false
 		},
 	}
 

--- a/controllers/storagecluster_controller_test.go
+++ b/controllers/storagecluster_controller_test.go
@@ -77,8 +77,5 @@ func TestReconcile(t *testing.T) {
 		err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
 			Name: fakeStorageCluster.Name, Namespace: fakeStorageCluster.Namespace}, foundStorageCluster)
 		assert.NoError(t, err)
-
-		_, ok := foundStorageCluster.ObjectMeta.Annotations[HasStorageSystemAnnotation]
-		assert.True(t, ok)
 	}
 }


### PR DESCRIPTION
adding an annotation to the storagecluster changes the resource version
of the storagecluster on etcd and ocs-operator fails to update the
status while onboarding the consumer.

There is no easy way to get the id of the storage consumer from the
provider again after the onboarding is successful from the provider end.

minimize the update calls wherever possible.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2056634