### PR TITLE
Added a "object storage" description about Ceph

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -93,8 +93,8 @@ spec:
     scope as well as watching and configuring their CustomResources.
 
     ### Rook
-    [Rook][1] deploys and manages Ceph on OpenShift, which provides block and
-    file storage.
+    [Rook][1] deploys and manages Ceph on OpenShift, which provides block,
+    file and object storage.
 
     ### NooBaa operator
     The NooBaa operator deploys and manages the [NooBaa][2] Multi-Cloud Gateway

--- a/config/manifests/bases/odf-operator.csv.card-description.yaml
+++ b/config/manifests/bases/odf-operator.csv.card-description.yaml
@@ -14,8 +14,8 @@ spec:
     scope as well as watching and configuring their CustomResources.
 
     ### Rook
-    [Rook][1] deploys and manages Ceph on OpenShift, which provides block and
-    file storage.
+    [Rook][1] deploys and manages Ceph on OpenShift, which provides block,
+    file and object storage.
 
     ### NooBaa operator
     The NooBaa operator deploys and manages the [NooBaa][2] Multi-Cloud Gateway


### PR DESCRIPTION
Sometimes people think that only with Noobaa they can create `ObjectBucketClaims`.
Probably they forget or don't know about the **ocs-external-storagecluster-ceph-rgw** `StorageClass`.
I added in the Ceph description the "object" volume type.
This is pretty simple, maybe don't do any difference at all but is good to tell about this.
From time to time I got someone thinking in this way.
Thank you!