### PR TITLE
test: Fix WaitForCsv fucntion in the deploymanager package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ODF_OPERATOR_UNINSTALL ?= true
 e2e-test: ginkgo ## Run end to end functional tests.
 	@echo "build and run e2e tests"
 	cd e2e/odf && $(GINKGO) build && ./odf.test \
-		--odf-catalog-image=$(CATALOG_IMG) --odf-subscription-channel=$(CHANNELS) --odf-cluster-service-version=odf-operator.v${VERSION} \
+		--odf-catalog-image=$(CATALOG_IMG) --odf-subscription-channel=$(CHANNELS) \
 		--odf-operator-install=$(ODF_OPERATOR_INSTALL) --odf-operator-uninstall=$(ODF_OPERATOR_UNINSTALL)
 
 define MANAGER_ENV_VARS

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -31,7 +31,6 @@ var (
 func init() {
 	flag.StringVar(&OdfCatalogSourceImage, "odf-catalog-image", "", "The ODF CatalogSource container image to use in the deployment")
 	flag.StringVar(&OdfSubscriptionChannel, "odf-subscription-channel", "", "The subscription channel to receive updates from")
-	flag.StringVar(&OdfClusterServiceVersion, "odf-cluster-service-version", "", "The CSV name which needs to verified")
 	flag.BoolVar(&OdfOperatorInstall, "odf-operator-install", true, "Install the ODF operator before starting tests")
 	flag.BoolVar(&OdfClusterUninstall, "odf-operator-uninstall", true, "Uninstall the ODF operator after test completion")
 	flag.Parse()
@@ -53,9 +52,5 @@ func verifyFlags() {
 
 	if OdfSubscriptionChannel == "" {
 		panic("odf-subscription-channel is not provided")
-	}
-
-	if OdfClusterServiceVersion == "" {
-		panic("odf-cluster-service-version is not provided")
 	}
 }

--- a/pkg/deploymanager/olm.go
+++ b/pkg/deploymanager/olm.go
@@ -210,7 +210,7 @@ func (d *DeployManager) WaitForCsv() error {
 
 		existingcsv := &operatorsv1alpha1.ClusterServiceVersionList{}
 		err = d.Client.List(d.Ctx, existingcsv, &client.ListOptions{Namespace: InstallNamespace})
-		if err != nil {
+		if err != nil || len(existingcsv.Items) == 0 {
 			lastReason = "Some error in csv"
 			return false, err
 		}


### PR DESCRIPTION
After the subscriptions are posted it takes some time for the Csvs to
come up. So in that time we shoudn't proceed with an empty csvlist.
This commit fixes that by checking for the csvlist is empty or not
before starting the wait.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>