### PR TITLE
godeps: Remove go install called on gomega

### DIFF
--- a/hack/make-tools.mk
+++ b/hack/make-tools.mk
@@ -32,7 +32,5 @@ opm: ## Download opm locally if necessary.
 
 
 GINKGO = $(BIN_DIR)/ginkgo
-GOMEGA = $(BIN_DIR)/gomega
-ginkgo: ## Download ginkgo and gomega locally if necessary.
+ginkgo: ## Download ginkgo locally if necessary.
 	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)
-	$(call go-get-tool,$(GOMEGA),github.com/onsi/gomega/...)


### PR DESCRIPTION
Gomega is just a matcher library and it's already in the
go.mod of our project. It need not be installed like the
ginkgo binary. Calling go install on gomega gives a
warning of matched no package.

Signedoff-by: Malay Kumar Parida <mparida@redhat.com>