### PR TITLE
makefile: update make-tools and remove unnecessary code

### DIFF
--- a/hack/make-tools.mk
+++ b/hack/make-tools.mk
@@ -1,13 +1,8 @@
 # go-get-tool will 'go get' any package $2 and install it to $1.
 define go-get-tool
 @[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
 }
 endef
 
@@ -21,6 +16,10 @@ KUSTOMIZE = $(BIN_DIR)/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.3)
 
+GINKGO = $(BIN_DIR)/ginkgo
+ginkgo: ## Download ginkgo locally if necessary.
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)
+
 OPERATOR_SDK = $(BIN_DIR)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
 	@./hack/get-tool.sh $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.14.0/operator-sdk_$(GOOS)_$(GOARCH)
@@ -29,8 +28,3 @@ operator-sdk: ## Download operator-sdk locally if necessary.
 OPM = $(BIN_DIR)/opm
 opm: ## Download opm locally if necessary.
 	@./hack/get-tool.sh $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(GOOS)-$(GOARCH)-opm
-
-
-GINKGO = $(BIN_DIR)/ginkgo
-ginkgo: ## Download ginkgo locally if necessary.
-	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)


### PR DESCRIPTION
while using go get we were always creating a new temp directory and go.mod. So go do not make any changes to the existing go.mod while downloading the binaries. This is not required anymore as go install does not make changes to the existing go.mod if we give the full path with version.

ref: https://go.dev/doc/go-get-install-deprecation

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>