### PR TITLE
test: Check for all the required CSV names in the SetUp function in the BeforeSuite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ ODF_OPERATOR_UNINSTALL ?= true
 e2e-test: ginkgo ## Run end to end functional tests.
 	@echo "build and run e2e tests"
 	cd e2e/odf && $(GINKGO) build && ./odf.test \
-		--odf-catalog-image=$(CATALOG_IMG) --odf-subscription-channel=$(CHANNELS) --odf-cluster-service-version=odf-operator.v${VERSION} \
-		--odf-operator-install=$(ODF_OPERATOR_INSTALL) --odf-operator-uninstall=$(ODF_OPERATOR_UNINSTALL)
+		--odf-catalog-image=$(CATALOG_IMG) --odf-subscription-channel=$(CHANNELS) \
+		--odf-operator-install=$(ODF_OPERATOR_INSTALL) --odf-operator-uninstall=$(ODF_OPERATOR_UNINSTALL) \
+		--odf-cluster-service-version=odf-operator.v${VERSION} \
+		--ocs-cluster-service-version=${OCS_SUBSCRIPTION_STARTINGCSV} \
+		--nooba-cluster-service-version=${NOOBAA_SUBSCRIPTION_STARTINGCSV} \
+		--csiaddons-cluster-service-version=${CSIADDONS_SUBSCRIPTION_STARTINGCSV}
 
 define MANAGER_ENV_VARS
 OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE)

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -12,12 +12,18 @@ var (
 	OdfCatalogSourceImage string
 	// OdfSubscriptionChannel is the name of the odf subscription channel
 	OdfSubscriptionChannel string
-	// OdfClusterServiceVersion is the name of odf csv
-	OdfClusterServiceVersion string
 	// OdfOperatorInstall indicates to install the operator
 	OdfOperatorInstall bool
-	//OdfClusterUninstall indicates to uninstall the operator
+	// OdfClusterUninstall indicates to uninstall the operator
 	OdfClusterUninstall bool
+	// OdfClusterServiceVersion is the name of odf csv
+	OdfClusterServiceVersion string
+	// OcsClusterServiceVersion is the name of ocs csv
+	OcsClusterServiceVersion string
+	// NoobaClusterServiceVersion is the name of Nooba csv
+	NoobaClusterServiceVersion string
+	// CsiaddonsClusterServiceVersion is the name of Csiaddons csv
+	CsiaddonsClusterServiceVersion string
 )
 
 var (
@@ -26,17 +32,27 @@ var (
 
 	// SuiteFailed indicates whether any test in the current suite has failed
 	SuiteFailed = false
+
+	// A list of all the csvs that should be installed
+	CsvNames []string
 )
 
 func init() {
 	flag.StringVar(&OdfCatalogSourceImage, "odf-catalog-image", "", "The ODF CatalogSource container image to use in the deployment")
 	flag.StringVar(&OdfSubscriptionChannel, "odf-subscription-channel", "", "The subscription channel to receive updates from")
-	flag.StringVar(&OdfClusterServiceVersion, "odf-cluster-service-version", "", "The CSV name which needs to verified")
 	flag.BoolVar(&OdfOperatorInstall, "odf-operator-install", true, "Install the ODF operator before starting tests")
 	flag.BoolVar(&OdfClusterUninstall, "odf-operator-uninstall", true, "Uninstall the ODF operator after test completion")
+	flag.StringVar(&OdfClusterServiceVersion, "odf-cluster-service-version", "", "The ODF CSV name which needs to verified")
+	flag.StringVar(&OcsClusterServiceVersion, "ocs-cluster-service-version", "", "The OCS CSV name which needs to verified")
+	flag.StringVar(&NoobaClusterServiceVersion, "nooba-cluster-service-version", "", "The Nooba CSV name which needs to verified")
+	flag.StringVar(&CsiaddonsClusterServiceVersion, "csiaddons-cluster-service-version", "", "The CSI Addon CSV name which needs to verified")
 	flag.Parse()
 
 	verifyFlags()
+
+	// A list of names of all the csvs that should be installed
+	CsvNames = []string{OdfClusterServiceVersion, OcsClusterServiceVersion,
+		NoobaClusterServiceVersion, CsiaddonsClusterServiceVersion}
 
 	dm, err := deploymanager.NewDeployManager()
 	if err != nil {
@@ -57,5 +73,17 @@ func verifyFlags() {
 
 	if OdfClusterServiceVersion == "" {
 		panic("odf-cluster-service-version is not provided")
+	}
+
+	if OcsClusterServiceVersion == "" {
+		panic("ocs-cluster-service-version is not provided")
+	}
+
+	if NoobaClusterServiceVersion == "" {
+		panic("nooba-cluster-service-version is not provided")
+	}
+
+	if CsiaddonsClusterServiceVersion == "" {
+		panic("csiaddons-cluster-service-version is not provided")
 	}
 }

--- a/e2e/setup_teardown.go
+++ b/e2e/setup_teardown.go
@@ -19,6 +19,10 @@ func Setup() {
 		err := DeployManager.DeployODFWithOLM(OdfCatalogSourceImage, OdfSubscriptionChannel, OdfClusterServiceVersion)
 		gomega.Expect(err).To(gomega.BeNil())
 	}
+	
+	debug("Setup: Checking if all the CSVs have succeeded\n")
+	err := DeployManager.CheckAllCsvs(CsvNames)
+	gomega.Expect(err).To(gomega.BeNil())
 
 	SuiteFailed = false
 


### PR DESCRIPTION
We check for all the CSVs, if they have reached succeeded state or not. This is done after the operator installation is completed in the SetUp Function in the BeforeSuite