### PR TITLE
console: update compatibility support matrix for 4.11

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -84,7 +84,7 @@ func GetConsolePluginCR(consolePort int, basePath string, serviceNamespace strin
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.11") {
+	if strings.Contains(clusterVersion, "4.12") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2082028

ODF 4.11 supports OCP 4.11 and 4.12.
Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>