### PR TITLE
test: Correct logical mistake in fixing panic happening in WaitForCatalogsource

### DIFF
--- a/pkg/deploymanager/olm.go
+++ b/pkg/deploymanager/olm.go
@@ -192,7 +192,11 @@ func (d *DeployManager) WaitForCatalogSource(catalogsource *operatorsv1alpha1.Ca
 			lastReason = fmt.Sprintf("failed to get catalogsource: %v", err)
 			return false, nil
 		}
-		if existingCatalogSource.Status.GRPCConnectionState != nil && existingCatalogSource.Status.GRPCConnectionState.LastObservedState != "READY" {
+		if existingCatalogSource.Status.GRPCConnectionState == nil {
+			lastReason = "catalogsource connection state is nil"
+			return false, nil
+		}
+		if existingCatalogSource.Status.GRPCConnectionState.LastObservedState != "READY" {
 			lastReason = fmt.Sprintf("waiting for catalog source to reach ready state, but stuck in %s state",
 				existingCatalogSource.Status.GRPCConnectionState.LastObservedState)
 			return false, nil


### PR DESCRIPTION
A Panic was happening in WaitForCatalogsource during runtime. So a
null check was added to It. But while doing so a logical mistake was
left behind which allowed it to return true even when the connection
state was nill. Now fixing it.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>