### PR TITLE
[wip] test: Add an Upgrade test into the e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,9 @@ e2e-test: ginkgo ## Run end to end functional tests.
 		--odf-cluster-service-version=odf-operator.v${VERSION} \
 		--ocs-cluster-service-version=${OCS_SUBSCRIPTION_STARTINGCSV} \
 		--nooba-cluster-service-version=${NOOBAA_SUBSCRIPTION_STARTINGCSV} \
-		--csiaddons-cluster-service-version=${CSIADDONS_SUBSCRIPTION_STARTINGCSV}
+		--csiaddons-cluster-service-version=${CSIADDONS_SUBSCRIPTION_STARTINGCSV} \
+		--upgrade-from-odf-catalogsource-image=${UPGRADE_FROM_ODF_CATALOG_IMAGE} \
+		--upgrade-from-odf-subscription-channel=${UPGRADE_FROM_ODF_SUBSCRIPTION_CHANNEL}
 
 define MANAGER_ENV_VARS
 OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE)

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -24,6 +24,10 @@ var (
 	NoobaClusterServiceVersion string
 	// CsiaddonsClusterServiceVersion is the name of Csiaddons csv
 	CsiaddonsClusterServiceVersion string
+	// UpgradeFromOdfCatalogSourceImage is the ODF CatalogSource container image to upgrade from in the deployment
+	UpgradeFromOdfCatalogSourceImage string
+	// UpgradeFromOdfSubscriptionChannel is the name of the ODF subscription channel to upgrade from
+	UpgradeFromOdfSubscriptionChannel string
 )
 
 var (
@@ -46,6 +50,8 @@ func init() {
 	flag.StringVar(&OcsClusterServiceVersion, "ocs-cluster-service-version", "", "The OCS CSV name which needs to verified")
 	flag.StringVar(&NoobaClusterServiceVersion, "nooba-cluster-service-version", "", "The Nooba CSV name which needs to verified")
 	flag.StringVar(&CsiaddonsClusterServiceVersion, "csiaddons-cluster-service-version", "", "The CSI Addon CSV name which needs to verified")
+	flag.StringVar(&UpgradeFromOdfCatalogSourceImage, "upgrade-from-odf-catalogsource-image", "", "The ODF CatalogSource image to upgrade from in the deployment")
+	flag.StringVar(&UpgradeFromOdfSubscriptionChannel, "upgrade-from-odf-subscription-channel", "", "The subscription channel to upgrade from")
 	flag.Parse()
 
 	verifyFlags()
@@ -85,5 +91,13 @@ func verifyFlags() {
 
 	if CsiaddonsClusterServiceVersion == "" {
 		panic("csiaddons-cluster-service-version is not provided")
+	}
+
+	if UpgradeFromOdfCatalogSourceImage == "" {
+		panic("upgrade-from-odf-catalogsource-image is not provided")
+	}
+
+	if UpgradeFromOdfSubscriptionChannel == "" {
+		panic("upgrade-from-odf-subscription-channel is not provided")
 	}
 }

--- a/e2e/odf/odf_suite_test.go
+++ b/e2e/odf/odf_suite_test.go
@@ -22,10 +22,19 @@ var _ = AfterSuite(func() {
 })
 
 // Test for the creation & deletion of storagesystem
-var _ = Describe("StorageSystem test", func() {
-	Context("Checking the StorageSystem", func() {
-		It("Should check the creation & deletion of storagesystem", func() {
-			tests.TestStorageSystem()
+// var _ = Describe("StorageSystem test", func() {
+// 	Context("Checking the StorageSystem", func() {
+// 		It("Should check the creation & deletion of storagesystem", func() {
+// 			tests.StorageSystemTest()
+// 		})
+// 	})
+// })
+
+// Test for the upgrade of odf operator
+var _= Describe("Upgrade test", func() {
+	Context("Checking the upgrade of odf operator", func() {
+		It("Should check the upgrade of odf operator", func() {
+			tests.UpgradeTest()
 		})
 	})
 })

--- a/e2e/odf_upgrade.go
+++ b/e2e/odf_upgrade.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"github.com/onsi/gomega"
+)
+
+// TestUpgrade tests the upgrade of ODF operator
+func UpgradeTest() {
+
+	debug("Upgrade Test: started\n")
+
+	SuiteFailed = true
+
+	debug("Upgrade Test: Uninstalling the current version of ODF\n")
+	err := DeployManager.BeforeUpgradeCleanup(OdfCatalogSourceImage, OdfSubscriptionChannel)
+	gomega.Expect(err).To(gomega.BeNil())
+
+	debug("Upgrade Test: Installing the upgradefrom version of ODF\n")
+	err = DeployManager.BeforeUpgradeSetup(UpgradeFromOdfCatalogSourceImage, UpgradeFromOdfSubscriptionChannel)
+	gomega.Expect(err).To(gomega.BeNil())
+
+	debug("Upgrade Test: Upgrading ODF\n")
+	err = DeployManager.UpgradeODFwithOLM(OdfCatalogSourceImage, OdfSubscriptionChannel)
+	gomega.Expect(err).To(gomega.BeNil())
+
+	debug("Upgrade Test: Waiting for Upgraded CSVs\n")
+	err = DeployManager.CheckAllCsvs(CsvNames)
+	gomega.Expect(err).To(gomega.BeNil())
+
+	debug("Upgrade Test: Checking the Storage System\n")
+	err = DeployManager.CheckStorageSystem()
+	gomega.Expect(err).To(gomega.BeNil())
+
+	debug("Upgrade Test: Cleanup resources after upgrade\n")
+	err = DeployManager.AfterUpgradeCleanup()
+	gomega.Expect(err).To(gomega.BeNil())
+
+	SuiteFailed = false
+
+	debug("Upgrade Test: completed\n")
+}

--- a/e2e/storage_system.go
+++ b/e2e/storage_system.go
@@ -3,7 +3,7 @@ package e2e
 import "github.com/onsi/gomega"
 
 // TestStorageSystem tests the creation & deletion of storagesystem
-func TestStorageSystem() {
+func StorageSystemTest() {
 
 	debug("Storagesystem Test: started\n")
 

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -50,6 +50,11 @@ BUNDLE_IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(BUNDLE_IMAGE_NAME):$(IMA
 # CATALOG_IMG defines the image used for the catalog.
 CATALOG_IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(CATALOG_IMAGE_NAME):$(IMAGE_TAG)
 
+# ENV Variables required for upgrade test in e2e tests
+UPGRADE_FROM_ODF_CATALOG_IMAGE ?= registry.redhat.io/redhat/redhat-operator-index:v4.10
+
+UPGRADE_FROM_ODF_SUBSCRIPTION_CHANNEL ?= stable-4.10
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/pkg/deploymanager/upgrade.go
+++ b/pkg/deploymanager/upgrade.go
@@ -1,0 +1,73 @@
+package deploymanager
+
+func (d *DeployManager) BeforeUpgradeCleanup(odfCatalogImage, subscriptionChannel string) error {
+	err := d.UndeployODFWithOLM(odfCatalogImage, subscriptionChannel)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+func (d *DeployManager) BeforeUpgradeSetup(upgradeFromodfCatalogImage, upgradeFromsubscriptionChannel string) error {
+	err := d.DeployODFWithOLM(upgradeFromodfCatalogImage, upgradeFromsubscriptionChannel)
+	if err != nil {
+		return err
+	}
+
+	csvNames, err := d.GetCSVNames()
+	if err != nil {
+		return err
+	}
+
+	err = d.CheckAllCsvs(csvNames)
+	if err != nil {
+		return err
+	}
+
+	// Creating a storagecluster which we will check after upgrade
+	err = d.CreateStorageSystem()
+	if err != nil {
+		return err
+	}
+	err = d.CheckStorageSystemCondition()
+	if err != nil {
+		return err
+	}
+	err = d.CheckStorageSystemOwnerRef()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DeployManager) UpgradeODFwithOLM(odfCatalogImage, subscriptionChannel string) error {
+	olmResources := d.GetOlmResources(odfCatalogImage, subscriptionChannel)
+	err := d.UpdateOlmResources(olmResources)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DeployManager) CheckStorageSystem() error {
+	err := d.CheckStorageSystemCondition()
+	if err != nil {
+		return err
+	}
+	err = d.CheckStorageSystemOwnerRef()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DeployManager) AfterUpgradeCleanup() error {
+	err := d.DeleteStorageSystemAndWait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds an upgrade test to the existing e2d testing in odf. We install an old version of odf and upgrade from it to the latest one.
After upgrading we check if all the csvs have succeded & whether the storagesystem is still healthy.