### PR TITLE
Bug 2093205:[release-4.10] bundle: Add csi-addons to the dependencies.yaml

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -3,3 +3,7 @@ dependencies:
   value:
     packageName: ocs-operator
     version: ">=4.9.0 <4.10.0 || 4.10.0"
+- type: olm.package
+  value:
+    packageName: csi-addons
+    version: "0.2.0"

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -57,6 +57,7 @@ func CheckExistingSubscriptions(cli client.Client, desiredSubscription *operator
 			}
 			actualSub = &subsList.Items[i]
 			actualSub.Spec.Channel = desiredSubscription.Spec.Channel
+			actualSub.Spec.Config = desiredSubscription.Spec.Config
 			desiredSubscription = actualSub
 		}
 	}


### PR DESCRIPTION
csi-addons resolution gets fail when user uses the custom catalog
source as it is not specified in the dependencies.yaml and the sub is
not created via OLM. The sub is created by the odf directly which does
not have a knowledge about the custom catalog source and it is still
pointing to the redhat-operators in the openshift-marketplace namespace.

Managing there own catalog source is seen very offently now a days as it
is MS and disconnected ENV usecase.

Signed-off-by: Nitin Goyal [nigoyal@redhat.com](mailto:nigoyal@redhat.com)

https://bugzilla.redhat.com/show_bug.cgi?id=2056697

Manual backport of https://github.com/red-hat-storage/odf-operator/pull/221