### PR TITLE
bundle: use extra label for odf-operator configs

### DIFF
--- a/bundle/manifests/odf-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/odf-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
   name: odf-operator-controller-manager-metrics-monitor
 spec:
@@ -14,4 +15,5 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: odf-operator
       control-plane: controller-manager

--- a/bundle/manifests/odf-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/odf-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
   name: odf-operator-controller-manager-metrics-service
 spec:
@@ -11,6 +12,7 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -376,6 +376,7 @@ spec:
           template:
             metadata:
               labels:
+                app.kubernetes.io/name: odf-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
   name: system
 ---
@@ -11,6 +12,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
 spec:
   selector:
@@ -20,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: odf-operator
         control-plane: controller-manager
     spec:
       securityContext:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
@@ -16,4 +17,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: odf-operator
       control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
@@ -11,4 +12,5 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -9,4 +9,5 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
+    app.kubernetes.io/name: odf-operator
     control-plane: controller-manager


### PR DESCRIPTION
The odf-operator-controller-manager-metrics-service uses only one label
control-plane: controller-manager as pod selector. A different pod also
uses the same label, the service does select the other pod as well along
with our pod and creates issues.

Add the extra label to solve this conflict.

The extra label has been added to all the places except the selector of
odf-operator-controller-manager deployment. As adding the extra label
there causes upgrade failure.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2089342