### PR TITLE
controllers: Add namespace as list option while listing resources

### DIFF
--- a/controllers/delete.go
+++ b/controllers/delete.go
@@ -34,7 +34,7 @@ func (r *StorageSystemReconciler) deleteResources(instance *odfv1alpha1.StorageS
 
 	var backendStorage client.Object
 
-	r.deleteQuickStarts(logger)
+	r.deleteQuickStarts(logger, instance)
 	if instance.Spec.Kind == VendorStorageCluster() {
 		backendStorage = &ocsv1.StorageCluster{}
 	} else if instance.Spec.Kind == VendorFlashSystemCluster() {
@@ -64,10 +64,10 @@ func (r *StorageSystemReconciler) deleteResources(instance *odfv1alpha1.StorageS
 	return fmt.Errorf("Waiting for %s %s to be deleted", instance.Spec.Kind, instance.Spec.Name)
 }
 
-func (r *StorageSystemReconciler) areAllStorageSystemsMarkedForDeletion() (bool, error) {
+func (r *StorageSystemReconciler) areAllStorageSystemsMarkedForDeletion(namespace string) (bool, error) {
 
 	var storageSystems odfv1alpha1.StorageSystemList
-	err := r.Client.List(context.TODO(), &storageSystems)
+	err := r.Client.List(context.TODO(), &storageSystems, &client.ListOptions{Namespace: namespace})
 	if err != nil {
 		return false, err
 	}

--- a/controllers/quickstarts.go
+++ b/controllers/quickstarts.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	consolev1 "github.com/openshift/api/console/v1"
+	odfv1alpha1 "github.com/red-hat-storage/odf-operator/api/v1alpha1"
 )
 
 func (r *StorageSystemReconciler) ensureQuickStarts(logger logr.Logger) error {
@@ -65,12 +66,12 @@ func (r *StorageSystemReconciler) ensureQuickStarts(logger logr.Logger) error {
 	return nil
 }
 
-func (r *StorageSystemReconciler) deleteQuickStarts(logger logr.Logger) {
+func (r *StorageSystemReconciler) deleteQuickStarts(logger logr.Logger, instance *odfv1alpha1.StorageSystem) {
 	if len(AllQuickStarts) == 0 {
 		logger.Info("No quickstarts found.")
 	}
 
-	allSSDeleted, err := r.areAllStorageSystemsMarkedForDeletion()
+	allSSDeleted, err := r.areAllStorageSystemsMarkedForDeletion(instance.Namespace)
 	if err != nil {
 		// Log the error but not fail the operator
 		logger.Error(err, "Failed to List", "Kind", "StorageSystem")

--- a/controllers/subscription_controller.go
+++ b/controllers/subscription_controller.go
@@ -65,7 +65,7 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	err = r.ensureSubscriptions(logger)
+	err = r.ensureSubscriptions(logger, req.NamespacedName.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -73,7 +73,7 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (r *SubscriptionReconciler) ensureSubscriptions(logger logr.Logger) error {
+func (r *SubscriptionReconciler) ensureSubscriptions(logger logr.Logger, namespace string) error {
 
 	var err error
 
@@ -81,7 +81,7 @@ func (r *SubscriptionReconciler) ensureSubscriptions(logger logr.Logger) error {
 	subsList[StorageClusterKind] = GetSubscriptions(StorageClusterKind)
 
 	ssList := &odfv1alpha1.StorageSystemList{}
-	err = r.Client.List(context.TODO(), ssList)
+	err = r.Client.List(context.TODO(), ssList, &client.ListOptions{Namespace: namespace})
 	if err != nil {
 		return err
 	}

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -42,7 +42,7 @@ import (
 func CheckExistingSubscriptions(cli client.Client, desiredSubscription *operatorv1alpha1.Subscription) (*operatorv1alpha1.Subscription, error) {
 
 	subsList := &operatorv1alpha1.SubscriptionList{}
-	err := cli.List(context.TODO(), subsList)
+	err := cli.List(context.TODO(), subsList, &client.ListOptions{Namespace: desiredSubscription.Namespace})
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func GetOdfSubscription(cli client.Client) (*operatorv1alpha1.Subscription, erro
 	}
 
 	subsList := &operatorv1alpha1.SubscriptionList{}
-	err := cli.List(context.TODO(), subsList)
+	err := cli.List(context.TODO(), subsList, &client.ListOptions{Namespace: OperatorNamespace})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To prevent listing of clusterwide resources unnecessarily, A list
option with the operator namespace as the desired namespace is added
to the places where we are trying to list any resources.

We are trying to fix this BZ [https://bugzilla.redhat.com/show_bug.cgi?id=2092737](https://bugzilla.redhat.com/show_bug.cgi?id=2092737)
Although we haven't been able to find any root cause due to the inability to reproduce the issue, We suspect the listing of unnecessary cluster-wide resources might be one of the causes. So fixing that.