### PR TITLE
reconcile csiaddons subscription first

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -288,7 +288,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	return []*operatorv1alpha1.Subscription{noobaaSubscription, ocsSubscription, csiAddonsSubscription}
+	return []*operatorv1alpha1.Subscription{csiAddonsSubscription, noobaaSubscription, ocsSubscription}
 }
 
 // GetFlashSystemClusterSubscription return subscription for FlashSystemCluster


### PR DESCRIPTION
CSIAddons has no dependencies and it provides
VR and VRC CRDs which will be required by
ocs-operator csv, hence reconcile first.

Signed-off-by: Rakshith R <rar@redhat.com>