### PR TITLE
Prevent subscription config override if it is not empty

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -57,7 +57,12 @@ func CheckExistingSubscriptions(cli client.Client, desiredSubscription *operator
 			}
 			actualSub = &subsList.Items[i]
 			actualSub.Spec.Channel = desiredSubscription.Spec.Channel
-			actualSub.Spec.Config = desiredSubscription.Spec.Config
+
+			// If the config is not set, only then set it to the desired value => allow user to override
+			if actualSub.Spec.Config == nil {
+				actualSub.Spec.Config = desiredSubscription.Spec.Config
+			}
+
 			desiredSubscription = actualSub
 		}
 	}


### PR DESCRIPTION
### Description
This PR prevents subscription config override if it is not empty. This change was made in order to allow users to be able to edit subscription if there is a need for the same (for eg. adding tolerations to underlying objects, etc.)

### Test
Following steps were taken to test the changes
1. Steps in the README were followed to deploy ODF with OLM on an OpenShift Cluster.
2. MCG Subscription was edited to add a toleration
3. Manual inspection of subscription confirmed that the config were no longer overridden.
4. Manual inspection of NooBaa operation confirmed that the toleration was propagated to the operator and was persisted.

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2122980