### PR TITLE
controllers: limit leaderElection & cache to operator namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -38,6 +39,7 @@ import (
 
 	odfv1alpha1 "github.com/red-hat-storage/odf-operator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-operator/controllers"
+	"github.com/red-hat-storage/odf-operator/pkg/util"
 
 	//+kubebuilder:scaffold:imports
 	configv1 "github.com/openshift/api/config/v1"
@@ -85,15 +87,26 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	operatorNamespace, err := util.GetOperatorNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to get operator namespace")
+		os.Exit(1)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "4fd470de.openshift.io",
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		Port:                    9443,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "4fd470de.openshift.io",
+		LeaderElectionNamespace: operatorNamespace,
+		Namespace:               operatorNamespace,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			Namespace: operatorNamespace,
+		}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,4 +36,13 @@ func DetermineOpenShiftVersion(client client.Client) (string, error) {
 		clusterVersion = version.Status.Desired.Version
 	}
 	return clusterVersion, nil
+}
+
+// GetOperatorNamespace returns the namespace where the operator is deployed.
+func GetOperatorNamespace() (string, error) {
+	ns, found := os.LookupEnv("OPERATOR_NAMESPACE")
+	if !found {
+		return "", fmt.Errorf("OPERATOR_NAMESPACE must be set")
+	}
+	return ns, nil
 }


### PR DESCRIPTION
Currently odf-operator is relying on the default "AllNamespaces" cache
in controller-runtime, which works by syncing all the Kubernetes
resources in the cluster. This initial informer cache sync is so huge
that it causes a sudden massive spike in the memory usage of the
operator. It causes OOMKilled failures for the odf-operator pods.

So odf-operator will now set the leaderElectionNamespace & the Manager
cache to the namespace where the operator is deployed. This will
ensure that the initial cache sync will only sync the resources in the
namespace where the operator is deployed.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2092737