### PR TITLE
console: update compatibility support matrix for 4.12

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -83,7 +83,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1alph
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.12") {
+	if strings.Contains(clusterVersion, "4.13") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.12 supports OCP 4.12 and 4.13.
Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>