### PR TITLE
makefile: build on ARM64 machine

### DIFF
--- a/hack/make-project-vars.mk
+++ b/hack/make-project-vars.mk
@@ -3,8 +3,8 @@ BIN_DIR := $(PROJECT_DIR)/bin
 ENVTEST_ASSETS_DIR := $(PROJECT_DIR)/testbin
 
 GOBIN ?= $(BIN_DIR)
-GOOS ?= linux
-GOARCH ?= amd64
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= https://proxy.golang.org/
 
 GO_LINT_IMG_LOCATION ?= golangci/golangci-lint


### PR DESCRIPTION
Take GOOS and GOARCH make variables from local host (instead of hard-coded linux/amd64), in order to enable build on ARM based machines.

Tested on centos-stream9 aarch64 machine.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>