### PR TITLE
Bug 2129852:controllers: limit leaderElection & cache to operator namespace

### DIFF
--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,4 +36,13 @@ func DetermineOpenShiftVersion(client client.Client) (string, error) {
 		clusterVersion = version.Status.Desired.Version
 	}
 	return clusterVersion, nil
+}
+
+// GetOperatorNamespace returns the namespace where the operator is deployed.
+func GetOperatorNamespace() (string, error) {
+	ns, found := os.LookupEnv("OPERATOR_NAMESPACE")
+	if !found {
+		return "", fmt.Errorf("OPERATOR_NAMESPACE must be set")
+	}
+	return ns, nil
 }


### PR DESCRIPTION
Currently odf-operator is relying on the default "AllNamespaces" cache in controller-runtime, which works by syncing all the Kubernetes resources in the cluster. This initial informer cache sync is so huge that it causes a sudden massive spike in the memory usage of the operator. It causes OOMKilled failures for the odf-operator pods.

So odf-operator will now set the leaderElectionNamespace & the Manager cache to the namespace where the operator is deployed. This will ensure that the initial cache sync will only sync the resources in the namespace where the operator is deployed.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>