### PR TITLE
console: configure securityContext for odf-console

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -470,6 +470,9 @@ spec:
                     memory: 512Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  seccompProfile:
+                    type: RuntimeDefault
                   capabilities:
                     drop:
                     - all
@@ -479,6 +482,7 @@ spec:
                   readOnly: true
               securityContext:
                 runAsNonRoot: true
+                readOnlyRootFilesystem: true
               tolerations:
               - effect: NoSchedule
                 key: node.ocs.openshift.io/storage

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -23,6 +23,9 @@ spec:
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - all
@@ -41,3 +44,4 @@ spec:
             secretName: odf-console-serving-cert
       securityContext:
         runAsNonRoot: true
+        readOnlyRootFilesystem: true


### PR DESCRIPTION
BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=2166417
Issue: 115558: Misconfigured Security Context Attribute For A Pod Or Container

set securityContext for odf-console pod/container as per best practices.
Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>