### PR TITLE
Revert "console: configure securityContext for odf-console"

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -470,9 +470,6 @@ spec:
                     memory: 512Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                  seccompProfile:
-                    type: RuntimeDefault
                   capabilities:
                     drop:
                     - all
@@ -482,7 +479,6 @@ spec:
                   readOnly: true
               securityContext:
                 runAsNonRoot: true
-                readOnlyRootFilesystem: true
               tolerations:
               - effect: NoSchedule
                 key: node.ocs.openshift.io/storage

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -23,9 +23,6 @@ spec:
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            seccompProfile:
-              type: RuntimeDefault
             capabilities:
               drop:
                 - all
@@ -44,4 +41,3 @@ spec:
             secretName: odf-console-serving-cert
       securityContext:
         runAsNonRoot: true
-        readOnlyRootFilesystem: true


### PR DESCRIPTION
This reverts commit 363419365ccd6c8fafe200e80b9d0bc0d9a232af.

SecurityContext: "readOnlyRootFilesystem: true" is causing odf-console pod crashloopbackoff. Nginx used downstream is trying to create some temp files but don't have access to do so, hence pod is never getting into "Running" status.

Will create a new PR without setting "readOnlyRootFilesystem" context for the container. And need to check why nginx wants such access.

Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>