### PR TITLE
console: update compatibility support matrix for 4.13

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -83,7 +83,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1alph
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.13") {
+	if strings.Contains(clusterVersion, "4.14") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.13 supports OCP 4.13 and 4.14.
Signed-off-by: Timothy Asir <tjeyasin@redhat.com>