### PR TITLE
Bug 2168036:[release-4.10] bundle: remove debug logging from the manager auth proxy patch

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -375,7 +375,7 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
-                - --v=10
+                - --v=0
                 image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9.0
                 name: kube-rbac-proxy
                 ports:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
Having v=10 dumps sensitive information like tokens, resulting in information leakage if these logs are obtained. The Kubebuilder team also made this fix. They are also using v=0 now.

Ref: https://github.com/kubernetes-sigs/kubebuilder/pull/2435

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2136852

Backport of https://github.com/red-hat-storage/odf-operator/pull/271