### PR TITLE
controllers: do not use odf sub cache

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -18,8 +18,6 @@ package controllers
 
 import (
 	"os"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -84,11 +82,6 @@ var (
 	IbmSubscriptionStartingCSV            = GetEnvOrDefault("IBM_SUBSCRIPTION_STARTINGCSV")
 	IbmSubscriptionCatalogSource          = GetEnvOrDefault("IBM_SUBSCRIPTION_CATALOGSOURCE")
 	IbmSubscriptionCatalogSourceNamespace = GetEnvOrDefault("IBM_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE")
-)
-
-var (
-	// It will be fetched only once and used the same always
-	OdfSubscriptionObjectMeta *metav1.ObjectMeta
 )
 
 const (

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -108,13 +108,8 @@ func SetOdfSubControllerReference(cli client.Client, obj client.Object) error {
 	return nil
 }
 
-// GetOdfSubscription returns the subscription for odf-operator and stores it in a global variable
-// for later use.
+// GetOdfSubscription returns the subscription for odf-operator.
 func GetOdfSubscription(cli client.Client) (*operatorv1alpha1.Subscription, error) {
-
-	if OdfSubscriptionObjectMeta != nil {
-		return &operatorv1alpha1.Subscription{ObjectMeta: *OdfSubscriptionObjectMeta}, nil
-	}
 
 	subsList := &operatorv1alpha1.SubscriptionList{}
 	err := cli.List(context.TODO(), subsList, &client.ListOptions{Namespace: OperatorNamespace})
@@ -124,16 +119,11 @@ func GetOdfSubscription(cli client.Client) (*operatorv1alpha1.Subscription, erro
 
 	for _, sub := range subsList.Items {
 		if sub.Spec.Package == OdfSubscriptionPackage {
-			OdfSubscriptionObjectMeta = &sub.ObjectMeta
-			break
+			return &sub, nil
 		}
 	}
 
-	if OdfSubscriptionObjectMeta == nil {
-		return nil, fmt.Errorf("odf-operator subscription not found")
-	}
-
-	return &operatorv1alpha1.Subscription{ObjectMeta: *OdfSubscriptionObjectMeta}, nil
+	return nil, fmt.Errorf("odf-operator subscription not found")
 }
 
 func GetVendorCsvNames(kind odfv1alpha1.StorageKind) []string {


### PR DESCRIPTION
Avoid using the cached sub of odf in a way that assumes it will always exist, because if someone deletes it, the odf operator will still have the same cache and will create new subs using the UID of the deleted odf sub. These new subs will then be marked for garbage collection by Kubernetes since the old odf sub UID no longer exists.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2178619