### PR TITLE
add nginx configurations for the odf-console

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -479,6 +479,9 @@ spec:
                 - mountPath: /var/serving-cert
                   name: odf-console-serving-cert
                   readOnly: true
+                - mountPath: /etc/nginx/nginx.conf
+                  name: odf-console-nginx-conf
+                  subPath: nginx.conf
               securityContext:
                 runAsNonRoot: true
               tolerations:
@@ -490,6 +493,9 @@ spec:
               - name: odf-console-serving-cert
                 secret:
                   secretName: odf-console-serving-cert
+              - configMap:
+                  name: odf-console-nginx-conf
+                name: odf-console-nginx-conf
       permissions:
       - rules:
         - apiGroups:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -32,6 +32,9 @@ spec:
             - name: odf-console-serving-cert
               mountPath: /var/serving-cert
               readOnly: true
+            - name: odf-console-nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
       tolerations:
       - effect: NoSchedule
         key: node.ocs.openshift.io/storage
@@ -41,5 +44,8 @@ spec:
         - name: odf-console-serving-cert
           secret:
             secretName: odf-console-serving-cert
+        - name: odf-console-nginx-conf
+          configMap:
+            name: odf-console-nginx-conf
       securityContext:
         runAsNonRoot: true

--- a/console/console.go
+++ b/console/console.go
@@ -38,6 +38,18 @@ func GetDeployment(namespace string) *appsv1.Deployment {
 	}
 }
 
+func GetNginxConfConfigMap(namespace string) *apiv1.ConfigMap {
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odf-console-nginx-conf",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"nginx.conf": NginxConf,
+		},
+	}
+}
+
 func GetService(port int, namespace string) *apiv1.Service {
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/nginx_conf.go
+++ b/console/nginx_conf.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 Red Hat OpenShift Data Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package console
+
+// Update it with correct configuration
+var NginxConf = `
+# Do not comment/un-comment without any reference.
+
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       9001 ssl;
+        listen       [::]:9001 ssl;
+        ssl_certificate /var/serving-cert/tls.crt;
+        ssl_certificate_key /var/serving-cert/tls.key;
+        location / {
+            root   /opt/app-root/src;
+        }
+        location /compatibility/ {
+            root   /opt/app-root/src;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+        ssi on;
+        add_header Last-Modified $date_gmt;
+        add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        if_modified_since off;
+        expires off;
+        etag off;
+    }
+
+}
+`

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -99,6 +99,15 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(clusterVersion string) er
 		return err
 	}
 
+	// Create/Update ODF console ConfigMap (nginx configuration)
+	odfConsoleConfigMap := console.GetNginxConfConfigMap(OperatorNamespace)
+	_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, odfConsoleConfigMap, func() error {
+		return controllerutil.SetControllerReference(odfConsoleDeployment, odfConsoleConfigMap, r.Scheme)
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
 	// Create/Update ODF console Service
 	odfConsoleService := console.GetService(r.ConsolePort, OperatorNamespace)
 	_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, odfConsoleService, func() error {


### PR DESCRIPTION
Changes required as per BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2139785

## **Resolves 4 issues:**

1.  BZ#2139785 itself: where on **disabling ipv6 address on the cluster nodes**, odf-console pod was resulting in error state (https://bugzilla.redhat.com/show_bug.cgi?id=2139785#c10)
2. There was CVE issue raised by IBM team where port 8080 was stated to be an insure port (https://bugzilla.redhat.com/show_bug.cgi?id=2166417). Port 8080 is present by default in the nginx configuration that we use for our pod (under `/etc/nginx/nginx.conf`: https://pastebin.com/ksX21dsr) and we did not had any control over that config earlier. Now all the nginx configurations (nginx's default and custom config for odf-console) are added via a ConfigMap created by odf-operator, so everything is under our control.
Also, now removed the port 8080 which was never needed and never used.
3. Earlier nginx configurations were added during build time, now they are added and can be easily updated during runtime.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4. There is one more CVE issue as per which we need to add `readOnlyRootFilesystem: true` spec for the odf-console pod, but on adding it is causing the UI's pod to go into an error state because nginx needs to create some files in pod's filesystem for its functioning but don't have access to do so (if we set this attribute), hence pod is never getting into "Running" status.
This PR adds the foundation for enabling us to be able to add the changes to fix this CVE **(will send a follow-up PR for that)**.

## **Possible improvement ?**
Currently for BZ#2139785 (if this PR gets merged), once odf-console pod errors due to ipv6 address issue, user will have to perform following operations (we will keep documentation team in loop):

1. Go to ConfigMap: `odf-console-nginx-conf` (introduced as part of this PR).
2. Comment out line `listen       [::]:9001 ssl;` --> `# listen       [::]:9001 ssl;`.
3. Restart the odf-console pod (just delete it) and Refresh.
Once done they will be able to see the UI once again as the pod will now be in `running` state.

We can automate this process so that user don;t have to take manual steps to resolve the issue.

**Pro:** no manual intervention needed.
**Cons:**

1. Not a priority (`P0`) use-case or something which is generally faced by users (rare).
2. odf-operator will need to introduce new a `controller` to keep a watch on resources which has nothing to do with ODF or storage, but are purely infra related.
3. This BZ is different from `IPv4/IPv6 dual-stack networking` where we can just watch over `network.config.openshift.io cluster` CR (https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)...
here we are disabling ipv6 addressing on the node's kernel level (https://access.redhat.com/solutions/5513111)... not sure if it is good idea to keep a watch for such changes.