### PR TITLE
console: securityContext: add 'readOnlyRootFilesystem'

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -473,6 +473,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                   seccompProfile:
                     type: RuntimeDefault
                 volumeMounts:
@@ -482,6 +483,10 @@ spec:
                 - mountPath: /etc/nginx/nginx.conf
                   name: odf-console-nginx-conf
                   subPath: nginx.conf
+                - mountPath: /var/log/nginx
+                  name: odf-console-nginx-log
+                - mountPath: /var/lib/nginx/tmp
+                  name: odf-console-nginx-tmp
               securityContext:
                 runAsNonRoot: true
               tolerations:
@@ -496,6 +501,10 @@ spec:
               - configMap:
                   name: odf-console-nginx-conf
                 name: odf-console-nginx-conf
+              - emptyDir: {}
+                name: odf-console-nginx-log
+              - emptyDir: {}
+                name: odf-console-nginx-tmp
       permissions:
       - rules:
         - apiGroups:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -25,6 +25,7 @@ spec:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -35,6 +36,10 @@ spec:
             - name: odf-console-nginx-conf
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: odf-console-nginx-log
+              mountPath: /var/log/nginx
+            - name: odf-console-nginx-tmp
+              mountPath: /var/lib/nginx/tmp
       tolerations:
       - effect: NoSchedule
         key: node.ocs.openshift.io/storage
@@ -47,5 +52,9 @@ spec:
         - name: odf-console-nginx-conf
           configMap:
             name: odf-console-nginx-conf
+        - name: odf-console-nginx-log
+          emptyDir: {}
+        - name: odf-console-nginx-tmp
+          emptyDir: {}
       securityContext:
         runAsNonRoot: true

--- a/console/nginx_conf.go
+++ b/console/nginx_conf.go
@@ -22,7 +22,7 @@ var NginxConf = `
 
 worker_processes auto;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+pid /var/lib/nginx/tmp/nginx.pid;
 
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;

--- a/console/nginx_conf.go
+++ b/console/nginx_conf.go
@@ -32,6 +32,13 @@ events {
 }
 
 http {
+    # Use directories writable by unprivileged users.
+    client_body_temp_path /var/lib/nginx/tmp/client_temp;
+    proxy_temp_path       /var/lib/nginx/tmp/proxy_temp_path;
+    fastcgi_temp_path     /var/lib/nginx/tmp/fastcgi_temp;
+    uwsgi_temp_path       /var/lib/nginx/tmp/uwsgi_temp;
+    scgi_temp_path        /var/lib/nginx/tmp/scgi_temp;
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2166417

NGINX requires some dirs to be writable so we enable 2 `emptyDir` volumes for that purpose and update the NGINX config with the path of those dirs.

NOTE: when using the downstream image, we noticed this in the pod logs:
```/opt/app-root/etc/generate_container_user: line 6: /opt/app-root/etc/passwd: Read-only file system```
After a conversation with @SanjalKatiyar and Boris Ranto we decided to not take any action on this as it has no side effects on the behavior of the container.