### PR TITLE
makefile: block OCP upgrades beyond the X+1 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,14 +143,16 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd config/console && $(KUSTOMIZE) edit set image odf-console=$(ODF_CONSOLE_IMG)
 ifneq ($(FUSION), true)
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)" && \
-	        $(KUSTOMIZE) edit add annotation --force 'operators.operatorframework.io/operator-type':"$(OPERATOR_TYPE)" && \
+	        $(KUSTOMIZE) edit add annotation --force 'operators.operatorframework.io/operator-type':"$(OPERATOR_TYPE)" \
+			'olm.properties':'[{"type": "olm.maxOpenShiftVersion", "value": "$(MAX_OCP_VERSION)"}]' && \
 		$(KUSTOMIZE) edit add patch --name odf-operator.v0.0.0 --kind ClusterServiceVersion\
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
 	cd config/manifests && $(KUSTOMIZE) edit remove resource fusion
 	cd config/manifests && $(KUSTOMIZE) edit add resource bases
 else
 	cd config/manifests/fusion && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)" && \
-	        $(KUSTOMIZE) edit add annotation --force 'operators.operatorframework.io/operator-type':"$(OPERATOR_TYPE)" && \
+	        $(KUSTOMIZE) edit add annotation --force 'operators.operatorframework.io/operator-type':"$(OPERATOR_TYPE)" \
+			'olm.properties':'[{"type": "olm.maxOpenShiftVersion", "value": "$(MAX_OCP_VERSION)"}]' && \
 		$(KUSTOMIZE) edit add patch --name odf-operator.v0.0.0 --kind ClusterServiceVersion\
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
 	cd config/manifests && $(KUSTOMIZE) edit remove resource bases

--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -37,6 +37,7 @@ metadata:
     containerImage: quay.io/ocs-dev/odf-operator:latest
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     olm.skipRange: ""
     operatorframework.io/initialization-resource: |-
       {

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -6,6 +6,7 @@ patchesStrategicMerge:
 - odf-operator.csv.icon.yaml
 - odf-operator.csv.card-description.yaml
 commonAnnotations:
+  olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
   olm.skipRange: ""
   operators.operatorframework.io/operator-type: standalone
 patches:

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -5,6 +5,10 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 4.13.0
 
+# MAX_OCP_VERSION variable specifies the maximum supported version of OCP.
+# Its purpose is to add an annotation to the CSV file, blocking OCP upgrades beyond the X+1 version.
+MAX_OCP_VERSION := $(shell echo $(VERSION) | awk -F. '{print $$1"."$$2+1}')
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:


### PR DESCRIPTION
The annotation will allow OCP upgrade till given max OCP version which
is X+1. For example the ODF version is 4.13 the max OCP version would
be 4.14.
    
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Ref: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html-single/operators/index#:~:text=If%20you%20know,the%20cluster%20version