### PR TITLE
console: Fixes reconciliation logic for console ConfigMap

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -38,6 +38,10 @@ func GetDeployment(namespace string) *appsv1.Deployment {
 	}
 }
 
+func GetNginxConfiguration() string {
+	return NginxConf
+}
+
 func GetNginxConfConfigMap(namespace string) *apiv1.ConfigMap {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The mutateFunciton is updated to modify the configmap

Currently, when ODF is upgraded the ConfigMap data does not get updated. Hence the container crashes. This updates the configmap which should stop the crash. 
The configmap holds configuration related to Nginx. 
In ODF 4.13 the pid directive was pointing to `/run/nginx.pid` which was updated to `/var/lib/nginx/tmp/nginx.pid`.
Based on above change we set `readOnlyRootFilesystem` to `true`. 
As the ConfigMap was not updated Nginx tried creating a file at `/run/nginx.pid`.
