### PR TITLE
console: update compatibility support matrix for 4.14

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -99,7 +99,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1alph
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.14") {
+	if strings.Contains(clusterVersion, "4.15") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.14 supports OCP 4.14 and 4.15.