### PR TITLE
Adds proxy for Provider mode backend in ConsolePlugin

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -94,6 +94,18 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1alph
 				Namespace: serviceNamespace,
 				Port:      int32(consolePort),
 			},
+			Proxy: []consolev1alpha1.ConsolePluginProxy{
+				{
+					Type:  consolev1alpha1.ProxyTypeService,
+					Alias: "provider-proxy",
+					Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
+						Name:      "ux-backend-proxy",
+						Namespace: serviceNamespace,
+						Port:      8888,
+					},
+					Authorize: true,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Adds proxy for console to connect to the token generation server. This is required for Provider mode on-boarding feature. 