### PR TITLE
bundle: Modify the name and reference of the sample storagesystem

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -8,12 +8,12 @@ metadata:
           "apiVersion": "odf.openshift.io/v1alpha1",
           "kind": "StorageSystem",
           "metadata": {
-            "name": "ibm-flashsystemcluster-storagesystem",
+            "name": "my-flashsystemcluster-storagesystem",
             "namespace": "openshift-storage"
           },
           "spec": {
             "kind": "flashsystemcluster.odf.ibm.com/v1alpha1",
-            "name": "ibm-flashsystemcluster",
+            "name": "my-flashsystemcluster",
             "namespace": "openshift-storage"
           }
         },
@@ -21,12 +21,12 @@ metadata:
           "apiVersion": "odf.openshift.io/v1alpha1",
           "kind": "StorageSystem",
           "metadata": {
-            "name": "ocs-storagecluster-storagesystem",
+            "name": "my-storagecluster-storagesystem",
             "namespace": "openshift-storage"
           },
           "spec": {
             "kind": "storagecluster.ocs.openshift.io/v1",
-            "name": "ocs-storagecluster",
+            "name": "my-storagecluster",
             "namespace": "openshift-storage"
           }
         }
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2023-12-12T05:53:20Z"
+    createdAt: "2024-02-09T04:53:49Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"

--- a/config/samples/ibm-flashsystemcluster-storagesystem.yaml
+++ b/config/samples/ibm-flashsystemcluster-storagesystem.yaml
@@ -1,9 +1,9 @@
 apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem
 metadata:
-  name: ibm-flashsystemcluster-storagesystem
+  name: my-flashsystemcluster-storagesystem
   namespace: openshift-storage
 spec:
   kind: flashsystemcluster.odf.ibm.com/v1alpha1
-  name: ibm-flashsystemcluster
+  name: my-flashsystemcluster
   namespace: openshift-storage

--- a/config/samples/ocs-storagecluster-storagesystem.yaml
+++ b/config/samples/ocs-storagecluster-storagesystem.yaml
@@ -1,9 +1,9 @@
 apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem
 metadata:
-  name: ocs-storagecluster-storagesystem
+  name: my-storagecluster-storagesystem
   namespace: openshift-storage
 spec:
   kind: storagecluster.ocs.openshift.io/v1
-  name: ocs-storagecluster
+  name: my-storagecluster
   namespace: openshift-storage


### PR DESCRIPTION
In certain instances customers unintentionally create two storagesystems to the same storagecluster. This becomes problematic when attempting to delete one storagesystem, as it triggers the deletion of the associated storagecluster. By changing the name and reference, we aim to prevent this issue from occurring.

It will make sure that even if they create the storagesystem from the OCP console it wont refer to the same storagecluster.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=2263441
https://bugzilla.redhat.com/show_bug.cgi?id=2254343