### PR TITLE
console: update compatibility support matrix for 4.16

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -111,7 +111,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1alph
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.16") {
+	if strings.Contains(clusterVersion, "4.17") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.16 supports OCP 4.16 and 4.17.