### PR TITLE
controller: reuse the context from reconcile

### DIFF
--- a/controllers/delete.go
+++ b/controllers/delete.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -41,7 +40,7 @@ func (r *StorageSystemReconciler) deleteResources(instance *odfv1alpha1.StorageS
 		backendStorage = &ibmv1alpha1.FlashSystemCluster{}
 	}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{
+	err := r.Client.Get(r.ctx, types.NamespacedName{
 		Name: instance.Spec.Name, Namespace: instance.Spec.Namespace},
 		backendStorage)
 
@@ -53,7 +52,7 @@ func (r *StorageSystemReconciler) deleteResources(instance *odfv1alpha1.StorageS
 		return err
 	}
 
-	err = r.Client.Delete(context.TODO(), backendStorage)
+	err = r.Client.Delete(r.ctx, backendStorage)
 	if err != nil {
 		logger.Error(err, "Failed to delete", "Kind", instance.Spec.Kind, "Name", instance.Spec.Name)
 		return err
@@ -67,7 +66,7 @@ func (r *StorageSystemReconciler) deleteResources(instance *odfv1alpha1.StorageS
 func (r *StorageSystemReconciler) areAllStorageSystemsMarkedForDeletion(namespace string) (bool, error) {
 
 	var storageSystems odfv1alpha1.StorageSystemList
-	err := r.Client.List(context.TODO(), &storageSystems, &client.ListOptions{Namespace: namespace})
+	err := r.Client.List(r.ctx, &storageSystems, &client.ListOptions{Namespace: namespace})
 	if err != nil {
 		return false, err
 	}

--- a/controllers/delete_test.go
+++ b/controllers/delete_test.go
@@ -67,6 +67,7 @@ func TestDeleteResources(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		ctx := context.TODO()
 		t.Logf("Case %d: %s\n", i+1, tc.label)
 
 		fakeStorageSystem := GetFakeStorageSystem(tc.kind)
@@ -83,7 +84,7 @@ func TestDeleteResources(t *testing.T) {
 
 			fakeStorageSystem.Spec.Name = vendorSystem.GetName()
 			fakeStorageSystem.Spec.Namespace = vendorSystem.GetNamespace()
-			err = fakeReconciler.Client.Create(context.TODO(), vendorSystem)
+			err = fakeReconciler.Client.Create(ctx, vendorSystem)
 			assert.NoError(t, err)
 		}
 
@@ -93,14 +94,14 @@ func TestDeleteResources(t *testing.T) {
 		// verify resource does not exist
 		if tc.kind == VendorStorageCluster() {
 			storageCluster := &ocsv1.StorageCluster{}
-			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
+			err = fakeReconciler.Client.Get(ctx, types.NamespacedName{
 				Name: fakeStorageSystem.Spec.Name, Namespace: fakeStorageSystem.Namespace},
 				storageCluster)
 			assert.True(t, errors.IsNotFound(err))
 
 		} else if tc.kind == VendorFlashSystemCluster() {
 			flashSystemCluster := &ibmv1alpha1.FlashSystemCluster{}
-			err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
+			err = fakeReconciler.Client.Get(ctx, types.NamespacedName{
 				Name: fakeStorageSystem.Spec.Name, Namespace: fakeStorageSystem.Namespace},
 				flashSystemCluster)
 			assert.True(t, errors.IsNotFound(err))

--- a/controllers/quickstarts.go
+++ b/controllers/quickstarts.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
-
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,10 +39,10 @@ func (r *StorageSystemReconciler) ensureQuickStarts(logger logr.Logger) error {
 			continue
 		}
 		found := consolev1.ConsoleQuickStart{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cqs.Name, Namespace: cqs.Namespace}, &found)
+		err = r.Client.Get(r.ctx, types.NamespacedName{Name: cqs.Name, Namespace: cqs.Namespace}, &found)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				err = r.Client.Create(context.TODO(), &cqs)
+				err = r.Client.Create(r.ctx, &cqs)
 				if err != nil {
 					logger.Error(err, "Failed to create quickstart", "Name", cqs.Name, "Namespace", cqs.Namespace)
 					return nil
@@ -56,7 +54,7 @@ func (r *StorageSystemReconciler) ensureQuickStarts(logger logr.Logger) error {
 			return nil
 		}
 		found.Spec = cqs.Spec
-		err = r.Client.Update(context.TODO(), &found)
+		err = r.Client.Update(r.ctx, &found)
 		if err != nil {
 			logger.Error(err, "Failed to update quickstart", "Name", cqs.Name, "Namespace", cqs.Namespace)
 			return nil
@@ -90,7 +88,7 @@ func (r *StorageSystemReconciler) deleteQuickStarts(logger logr.Logger, instance
 			continue
 		}
 
-		err = r.Client.Delete(context.TODO(), &cqs)
+		err = r.Client.Delete(r.ctx, &cqs)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				continue

--- a/controllers/quickstarts_test.go
+++ b/controllers/quickstarts_test.go
@@ -140,7 +140,6 @@ func TestDeleteQuickStarts(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Logf("Case %d: %s\n", i+1, tc.label)
-
 		fakeReconciler := GetFakeStorageSystemReconciler(t)
 
 		err := fakeReconciler.ensureQuickStarts(fakeReconciler.Log)
@@ -150,11 +149,11 @@ func TestDeleteQuickStarts(t *testing.T) {
 		assert.Equal(t, 2, len(quickstarts))
 
 		for i := range tc.createStorageSystems {
-			err = fakeReconciler.Client.Create(context.TODO(), &tc.createStorageSystems[i])
+			err = fakeReconciler.Client.Create(fakeReconciler.ctx, &tc.createStorageSystems[i])
 			assert.NoError(t, err)
 		}
 		for i := range tc.deleteStorageSystems {
-			err := fakeReconciler.Client.Delete(context.TODO(), &tc.deleteStorageSystems[i])
+			err := fakeReconciler.Client.Delete(fakeReconciler.ctx, &tc.deleteStorageSystems[i])
 			assert.NoError(t, err)
 			err = fakeReconciler.deleteResources(&tc.deleteStorageSystems[i], fakeReconciler.Log)
 			assert.NoError(t, err)

--- a/controllers/storagesystem_controller_fake.go
+++ b/controllers/storagesystem_controller_fake.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,7 @@ func GetFakeStorageSystemReconciler(t *testing.T, objs ...runtime.Object) *Stora
 
 	scheme := createFakeScheme(t)
 	fakeStorageSystemReconciler := &StorageSystemReconciler{
+		ctx:      context.TODO(),
 		Client:   fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build(),
 		Log:      ctrl.Log.WithName("controllers").WithName("StorageSystem"),
 		Scheme:   scheme,

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,6 @@ func TestEnsureSubscription(t *testing.T) {
 
 		for _, kind := range KnownKinds {
 			var err error
-
 			fakeStorageSystem := GetFakeStorageSystem(kind)
 			fakeReconciler := GetFakeStorageSystemReconciler(t, fakeStorageSystem)
 			subs := GetSubscriptions(kind)
@@ -60,7 +58,7 @@ func TestEnsureSubscription(t *testing.T) {
 				for _, subscription := range subs {
 					sub := subscription.DeepCopy()
 					sub.Spec.Channel = "fake-channel"
-					err = fakeReconciler.Client.Create(context.TODO(), sub)
+					err = fakeReconciler.Client.Create(fakeReconciler.ctx, sub)
 					assert.NoError(t, err)
 				}
 			}
@@ -85,7 +83,7 @@ func TestEnsureSubscription(t *testing.T) {
 					},
 				},
 			}
-			err = fakeReconciler.Client.Create(context.TODO(), odfSub)
+			err = fakeReconciler.Client.Create(fakeReconciler.ctx, odfSub)
 			assert.NoError(t, err)
 
 			err = fakeReconciler.ensureSubscriptions(fakeStorageSystem, fakeReconciler.Log)
@@ -101,7 +99,7 @@ func TestEnsureSubscription(t *testing.T) {
 				}
 
 				actualSubscription := &operatorv1alpha1.Subscription{}
-				err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: expectedSubscription.Name, Namespace: expectedSubscription.Namespace}, actualSubscription)
+				err = fakeReconciler.Client.Get(fakeReconciler.ctx, types.NamespacedName{Name: expectedSubscription.Name, Namespace: expectedSubscription.Namespace}, actualSubscription)
 				assert.NoError(t, err)
 
 				assert.Equal(t, expectedSubscription.Spec, actualSubscription.Spec)

--- a/controllers/vendors.go
+++ b/controllers/vendors.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"reflect"
 	"strings"
 
@@ -69,11 +68,11 @@ func (r *StorageSystemReconciler) isVendorSystemPresent(instance *odfv1alpha1.St
 		vendorSystem = &ibmv1alpha1.FlashSystemCluster{}
 	}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.Name, Namespace: instance.Spec.Namespace}, vendorSystem)
+	err := r.Client.Get(r.ctx, types.NamespacedName{Name: instance.Spec.Name, Namespace: instance.Spec.Namespace}, vendorSystem)
 	if err == nil {
 		logger.Info("Vendor system found", "Name", instance.Spec.Name)
 		SetVendorSystemPresentCondition(&instance.Status.Conditions, corev1.ConditionTrue, "Found", "")
-		_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, vendorSystem, func() error {
+		_, err = controllerutil.CreateOrUpdate(r.ctx, r.Client, vendorSystem, func() error {
 			return controllerutil.SetOwnerReference(instance, vendorSystem, r.Scheme)
 		})
 		if err != nil && !errors.IsAlreadyExists(err) {

--- a/controllers/vendors_test.go
+++ b/controllers/vendors_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,6 @@ func TestIsVendorSystemPresent(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Logf("Case %d: %s\n", i+1, tc.label)
-
 		fakeStorageSystem := GetFakeStorageSystem(StorageClusterKind)
 		fakeReconciler := GetFakeStorageSystemReconciler(t, fakeStorageSystem)
 
@@ -62,7 +60,7 @@ func TestIsVendorSystemPresent(t *testing.T) {
 					Namespace: fakeStorageSystem.Spec.Namespace,
 				},
 			}
-			err := fakeReconciler.Client.Create(context.TODO(), storageCluster)
+			err := fakeReconciler.Client.Create(fakeReconciler.ctx, storageCluster)
 			assert.NoError(t, err)
 		}
 

--- a/pkg/deploymanager/olm.go
+++ b/pkg/deploymanager/olm.go
@@ -229,7 +229,9 @@ func (d *DeployManager) WaitForCsv(csv *operatorsv1alpha1.ClusterServiceVersion)
 			return false, nil
 		}
 		if existingcsv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
-			lastReason = fmt.Sprintf("waiting for CSV to succeed, but stuck in %s phase", existingcsv.Status.Phase)
+			// add complete status to lastReason which helps to understand what
+			// went wrong in testing.
+			lastReason = fmt.Sprintf("waiting for CSV to succeed, but stuck in %s phase with status:%+v", existingcsv.Status.Phase, existingcsv.Status)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -25,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func DetermineOpenShiftVersion(client client.Client) (string, error) {
+func DetermineOpenShiftVersion(ctx context.Context, client client.Client) (string, error) {
 	// Determine ocp version
 	clusterVersionList := configv1.ClusterVersionList{}
-	if err := client.List(context.TODO(), &clusterVersionList); err != nil {
+	if err := client.List(ctx, &clusterVersionList); err != nil {
 		return "", err
 	}
 	clusterVersion := ""


### PR DESCRIPTION
We dont need to create a new context for each time for a reconcile we should use the ctx from the Reconcile for all the dependent operations.