### PR TITLE
Bug 2276913:[release-4.16] controllers: do not skip rook subscription reconcile

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -198,6 +198,13 @@ func EnsureDesiredSubscription(cli client.Client, desiredSubscription *operatorv
 		return err
 	}
 
+	// rook is the ocs deps in the 4.16, We should not create the subscription.
+	// We should only update it if it is already there to add tolerations etc.
+	if desiredSubscription.Spec.Package == RookSubscriptionPackage &&
+		desiredSubscription.ObjectMeta.CreationTimestamp.IsZero() {
+		return nil
+	}
+
 	// create/update subscription
 	sub := &operatorv1alpha1.Subscription{}
 	sub.ObjectMeta = desiredSubscription.ObjectMeta
@@ -436,7 +443,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	_ = &operatorv1alpha1.Subscription{
+	rookSubscription := &operatorv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      RookSubscriptionName,
 			Namespace: OperatorNamespace,
@@ -466,7 +473,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	return []*operatorv1alpha1.Subscription{ocsSubscription, noobaaSubscription,
+	return []*operatorv1alpha1.Subscription{ocsSubscription, rookSubscription, noobaaSubscription,
 		csiAddonsSubscription, ocsClientSubscription, prometheusSubscription}
 }
 

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -100,6 +100,10 @@ func TestEnsureSubscription(t *testing.T) {
 					expectedSubscription.Spec.Config.Tolerations = getMergedTolerations(odfSub.Spec.Config.Tolerations, expectedSubscription.Spec.Config.Tolerations)
 				}
 
+				if expectedSubscription.Spec.Package == RookSubscriptionPackage {
+					continue
+				}
+
 				actualSubscription := &operatorv1alpha1.Subscription{}
 				err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: expectedSubscription.Name, Namespace: expectedSubscription.Namespace}, actualSubscription)
 				assert.NoError(t, err)


### PR DESCRIPTION
skipping rook subscription reconcile lead to the tolerations being absent from the rook subscription.

This fix is only required in 4.16 due to the #399

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
