### PR TITLE
Revert "bundle: remove rook as a dependency to allow upgrades from 4.15 to 4.16"

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -5,6 +5,10 @@ dependencies:
     version: ">=4.15.0 <=4.16.0"
 - type: olm.package
   value:
+    packageName: rook-ceph-operator
+    version: ">=4.15.0 <=4.16.0"
+- type: olm.package
+  value:
     packageName: ocs-client-operator
     version: ">=4.15.0 <=4.16.0"
 - type: olm.package

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -436,7 +436,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	_ = &operatorv1alpha1.Subscription{
+	rookSubscription := &operatorv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      RookSubscriptionName,
 			Namespace: OperatorNamespace,
@@ -481,7 +481,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	return []*operatorv1alpha1.Subscription{ocsSubscription, noobaaSubscription,
+	return []*operatorv1alpha1.Subscription{ocsSubscription, rookSubscription, noobaaSubscription,
 		csiAddonsSubscription, ocsClientSubscription, prometheusSubscription, recipeSubscription}
 }
 


### PR DESCRIPTION
This reverts commit 8907814c021e38ef776ce95dff51d18d5fecf85b.

4.17 onwards odf will take a ownership over rook and bring it as a OLM deps.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Related PR: #399, #402
