### PR TITLE
controllers: Do not manage csi addons if running in provider mode

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -53,7 +53,9 @@ func CheckExistingSubscriptions(cli client.Client, desiredSubscription *operator
 	}
 
 	var isProvider bool
-	if desiredSubscription.Spec.Package == OcsClientSubscriptionPackage {
+	if desiredSubscription.Spec.Package == OcsClientSubscriptionPackage ||
+		desiredSubscription.Spec.Package == CSIAddonsSubscriptionPackage {
+
 		isProvider, err = isProviderMode(cli)
 		if err != nil {
 			return nil, err
@@ -255,10 +257,10 @@ func GetVendorCsvNames(cli client.Client, kind odfv1alpha1.StorageKind) ([]strin
 		csvNames = []string{IbmSubscriptionStartingCSV}
 	} else if kind == VendorStorageCluster() {
 		csvNames = []string{OcsSubscriptionStartingCSV, RookSubscriptionStartingCSV, NoobaaSubscriptionStartingCSV,
-			CSIAddonsSubscriptionStartingCSV, PrometheusSubscriptionStartingCSV, RecipeSubscriptionStartingCSV}
+			PrometheusSubscriptionStartingCSV, RecipeSubscriptionStartingCSV}
 
 		if isProvider, err = isProviderMode(cli); !isProvider {
-			csvNames = append(csvNames, OcsClientSubscriptionStartingCSV)
+			csvNames = append(csvNames, OcsClientSubscriptionStartingCSV, CSIAddonsSubscriptionStartingCSV)
 		}
 	}
 


### PR DESCRIPTION
CSI addons will be managed by the ocs-client-operator in the provider mode.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2280818

Related PR: #393 
