### PR TITLE
Add the option to download the ODF CLI tool from the UI

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2024-05-15T04:40:51Z"
+    createdAt: "2024-05-21T10:23:39Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"
@@ -211,6 +211,14 @@ spec:
           verbs:
           - get
           - patch
+          - update
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          verbs:
+          - create
+          - get
           - update
         - apiGroups:
           - console.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,14 @@ rules:
 - apiGroups:
   - console.openshift.io
   resources:
+  - consoleclidownloads
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - console.openshift.io
+  resources:
   - consoleplugins
   verbs:
   - create

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"github.com/red-hat-storage/odf-operator/console"
 	"github.com/red-hat-storage/odf-operator/pkg/util"
 )
@@ -89,7 +88,10 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(clusterVersion string) er
 	logger := log.FromContext(context.TODO())
 	// The base path to where the request are sent
 	basePath := console.GetBasePath(clusterVersion)
-	nginxConf := console.GetNginxConfiguration()
+	nginxConf := console.NginxConf
+
+	// Customer portal link (CLI Tool download)
+	portalLink := console.CUSTOMER_PORTAL_LINK
 
 	// Get ODF console Deployment
 	odfConsoleDeployment := console.GetDeployment(OperatorNamespace)
@@ -131,28 +133,23 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(clusterVersion string) er
 			odfConsolePlugin.Spec.Service.BasePath = basePath
 		}
 		if odfConsolePlugin.Spec.Proxy == nil {
-			odfConsolePlugin.Spec.Proxy = []consolev1alpha1.ConsolePluginProxy{
-				{
-					Type:  consolev1alpha1.ProxyTypeService,
-					Alias: "provider-proxy",
-					Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
-						Name:      "ux-backend-proxy",
-						Namespace: OperatorNamespace,
-						Port:      8888,
-					},
-					Authorize: true,
-				},
-				{
-					Type:  consolev1alpha1.ProxyTypeService,
-					Alias: "rosa-prometheus",
-					Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
-						Name:      "prometheus",
-						Namespace: OperatorNamespace,
-						Port:      9339,
-					},
-					Authorize: false,
-				},
-			}
+			odfConsolePlugin.Spec.Proxy = console.GetConsolePluginProxy(OperatorNamespace)
+		}
+		return nil
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Create/Update ConsoleCLIDownload (CLI Tool download)
+	consoleCLIDownload := console.GetConsoleCLIDownloadCR()
+	_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, consoleCLIDownload, func() error {
+		if currentPortalLink := consoleCLIDownload.Spec.Links[0].Href; currentPortalLink != portalLink {
+			logger.Info(fmt.Sprintf("Set the customer portal link for CLI Tool '%s'", portalLink))
+			consoleCLIDownload.Spec.Links[0].Href = portalLink
+		}
+		if len(consoleCLIDownload.Spec.Links) != 1 {
+			consoleCLIDownload.Spec.Links = console.GetConsoleCLIDownloadLinks()
 		}
 		return nil
 	})

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -48,6 +48,7 @@ type ClusterVersionReconciler struct {
 //+kubebuilder:rbac:groups="apps",resources=deployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;create;update
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile


### PR DESCRIPTION
https://issues.redhat.com/browse/RHSTOR-5204

No straight-forward/correct way of CLI Tool CR deletion (clean-up) is currently possible (**during operator uninstallation**).
1. Tried deleting from `clusterversion_controller`, as part of reconcile (https://github.com/red-hat-storage/odf-operator/pull/410#discussion_r1607017878).
2. Tried adding CR as part of the ODF bundle for OLM to maintain (https://github.com/operator-framework/operator-registry/blob/master/pkg/lib/bundle/supported_resources.go#L21 & https://github.com/red-hat-storage/odf-operator/pull/417#discussion_r1608233489).
3. One other way could be to add a finaliser to the manager pod which will be removed by `clusterversion_controller` once clean-up is done, but dropped this approach entirely after discussion due to hack-ish nature.

This PR handles CLI Tool CR creation as part of `clusterversion_controller` and deletion will be a manual step which needs to be documented.