### PR TITLE
Bug 2274099: [release-4.14] bundle: add readOnlyRootFilesystem for odf-operator

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2023-12-20T04:32:33Z"
+    createdAt: "2024-04-05T07:02:02Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
@@ -418,6 +418,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -459,6 +460,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: odf-operator-controller-manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,6 +24,7 @@ spec:
           capabilities:
             drop:
               - ALL
+          readOnlyRootFilesystem: true
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,6 +49,7 @@ spec:
           capabilities:
             drop:
               - ALL
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This is a manual cherry-pick of #396 