### PR TITLE
Add 'ConsolePluginBackendType' spec to the ConsolePlugin + Update compatibility support matrix for 4.17 

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -122,6 +122,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1.Con
 					Namespace: serviceNamespace,
 					Port:      int32(consolePort),
 				},
+				Type: consolev1.Service,
 			},
 			I18n: consolev1.ConsolePluginI18n{
 				LoadType: consolev1.Empty,

--- a/console/console.go
+++ b/console/console.go
@@ -133,7 +133,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1.Con
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.17") {
+	if strings.Contains(clusterVersion, "4.18") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
Follow up https://github.com/red-hat-storage/odf-operator/pull/434

> oc logs odf-operator-controller-manager-5f55f66644-pbmj9
> [...]
> ERROR	setup	problem running manager	{"error": "[ConsolePlugin.console.openshift.io](http://consoleplugin.console.openshift.io/) \"odf-console\" is invalid: spec.backend.type: Unsupported value: \"\": supported values: \"Service\""}