### PR TITLE
controllers: delete the webhook created by the ocs-client-operator

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -159,6 +159,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - delete
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - delete
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -63,6 +63,7 @@ type StorageSystemReconciler struct {
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=get;list;create;update;delete
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=delete
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"go.uber.org/multierr"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -346,6 +347,16 @@ func EnsureVendorCsv(cli client.Client, csvName string) (*operatorv1alpha1.Clust
 
 			for i := range csvObj.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
 				csvObj.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Spec.Replicas = &replicas
+			}
+
+			if replicas == 0 {
+				// delete the subscription webhook created by the ocs-client-operator
+				// we can not delete the webhook by the ocs-client-operator itself because the client operator is down
+				webhook := &admv1.ValidatingWebhookConfiguration{}
+				webhook.Name = "subscription.ocs.openshift.io"
+				if err = cli.Delete(context.TODO(), webhook); err != nil && !errors.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
Delete the webhook created by the ocs-client-operator as the client operator is already down in the 4.16.1 and it can not delete the webhook itself. Deleting the webhook will allow us the upgrades from 4.16 to 4.17. Otherwise it will always hit an error "failed calling webhook" while updating the channel of the ocs-client-operator subscription.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2304073
