### PR TITLE
controllers: scale down ocs-client-op csv in non-provider mode

### DIFF
--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -220,6 +220,9 @@ func (r *StorageSystemReconciler) ensureSubscriptions(instance *odfv1alpha1.Stor
 }
 
 func (r *StorageSystemReconciler) isVendorCsvReady(instance *odfv1alpha1.StorageSystem, logger logr.Logger) error {
+	if err := ScaleDownClientOperator(r.Client, instance.Spec.Kind); err != nil {
+		return err
+	}
 
 	csvNames, err := GetVendorCsvNames(r.Client, instance.Spec.Kind)
 	if err != nil {

--- a/controllers/subscription_controller.go
+++ b/controllers/subscription_controller.go
@@ -121,6 +121,10 @@ func (r *SubscriptionReconciler) ensureSubscriptions(logger logr.Logger, namespa
 	}
 
 	for kind := range subsList {
+		if err := ScaleDownClientOperator(r.Client, kind); err != nil {
+			return err
+		}
+
 		csvNames, csvErr := GetVendorCsvNames(r.Client, kind)
 		if csvErr != nil {
 			return csvErr


### PR DESCRIPTION
t0: odf-op w/ X.Y.Z is installed and all dependecies at same version will be installed
t1: odf-op is upgraded from X.Y.Z to X.(Y+1).0 and update will happen for odf-op unless there are explicit not upgradeable conditions set
t2: dependencies will first get updated from X.Y.Z to X.Y.(Z+1) if the channel has the update, now if one of the dependencies is stuck odf-op keeps trying to check for upgraded install plan which will not be created due to previous install plan for dependencies not being fulfilled.

now, odf-op always tries to scale down client-op if not in provider mode in above scenario t1 & t2 aren't strictly linear and odf-op ended up scaling down X.Y.Z version of client-op but not X.Y.(Z+1) which will never reach running state if cluster is configured as non-provider mode.

current PR makes sure that client-op csv & deployments are always scaled down for all non-provider cases.