### PR TITLE
console: update compatibility support matrix for 4.18

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -133,7 +133,7 @@ func GetConsolePluginCR(consolePort int, serviceNamespace string) *consolev1.Con
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.18") {
+	if strings.Contains(clusterVersion, "4.19") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.18 supports OCP 4.18 and 4.19.