### PR TITLE
check CSV phase to be succeeded for container readiness 

### DIFF
--- a/bundle/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2024-11-13T13:01:04Z"
+    createdAt: "2024-11-15T06:44:22Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"
@@ -418,6 +418,7 @@ spec:
                     port: 8081
                   initialDelaySeconds: 5
                   periodSeconds: 10
+                  timeoutSeconds: 90
                 resources:
                   limits:
                     cpu: 200m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,7 @@ spec:
             drop:
               - ALL
           readOnlyRootFilesystem: true
+        # ref https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
         livenessProbe:
           httpGet:
             path: /healthz
@@ -62,6 +63,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 90
         resources:
           limits:
             cpu: 200m

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -24,6 +24,13 @@ var (
 	DefaultValMap = map[string]string{
 		"OPERATOR_NAMESPACE": "openshift-storage",
 
+		"ODF_DEPS_SUBSCRIPTION_NAME":                    "odf-dependencies",
+		"ODF_DEPS_SUBSCRIPTION_PACKAGE":                 "odf-dependencies",
+		"ODF_DEPS_SUBSCRIPTION_CHANNEL":                 "alpha",
+		"ODF_DEPS_SUBSCRIPTION_STARTINGCSV":             "odf-dependencies.v4.18.0",
+		"ODF_DEPS_SUBSCRIPTION_CATALOGSOURCE":           "odf-catalogsource",
+		"ODF_DEPS_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE": "openshift-marketplace",
+
 		"NOOBAA_SUBSCRIPTION_NAME":                    "noobaa-operator",
 		"NOOBAA_SUBSCRIPTION_PACKAGE":                 "noobaa-operator",
 		"NOOBAA_SUBSCRIPTION_CHANNEL":                 "alpha",
@@ -89,6 +96,13 @@ var (
 	}
 
 	OperatorNamespace = GetEnvOrDefault("OPERATOR_NAMESPACE")
+
+	OdfDepsSubscriptionName                   = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_NAME")
+	OdfDepsSubscriptionPackage                = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_PACKAGE")
+	OdfDepsSubscriptionChannel                = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_CHANNEL")
+	OdfDepsSubscriptionStartingCSV            = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_STARTINGCSV")
+	OdfDepsSubscriptionCatalogSource          = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_CATALOGSOURCE")
+	OdfDepsSubscriptionCatalogSourceNamespace = GetEnvOrDefault("ODF_DEPS_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE")
 
 	OcsSubscriptionName                   = GetEnvOrDefault("OCS_SUBSCRIPTION_NAME")
 	OcsSubscriptionPackage                = GetEnvOrDefault("OCS_SUBSCRIPTION_PACKAGE")

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -262,7 +262,7 @@ func GetVendorCsvNames(cli client.Client, kind odfv1alpha1.StorageKind) ([]strin
 	if kind == VendorFlashSystemCluster() {
 		csvNames = []string{IbmSubscriptionStartingCSV}
 	} else if kind == VendorStorageCluster() {
-		csvNames = []string{OcsSubscriptionStartingCSV, RookSubscriptionStartingCSV, NoobaaSubscriptionStartingCSV,
+		csvNames = []string{OdfDepsSubscriptionStartingCSV, OcsSubscriptionStartingCSV, RookSubscriptionStartingCSV, NoobaaSubscriptionStartingCSV,
 			PrometheusSubscriptionStartingCSV, RecipeSubscriptionStartingCSV}
 
 		isProvider, err = isProviderMode(cli)
@@ -432,6 +432,22 @@ func GetSubscriptions(k odfv1alpha1.StorageKind) []*operatorv1alpha1.Subscriptio
 
 // GetStorageClusterSubscription return subscription for StorageCluster
 func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
+
+	odfDepsSubscription := &operatorv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OdfDepsSubscriptionName,
+			Namespace: OperatorNamespace,
+		},
+		Spec: &operatorv1alpha1.SubscriptionSpec{
+			CatalogSource:          OdfDepsSubscriptionCatalogSource,
+			CatalogSourceNamespace: OdfDepsSubscriptionCatalogSourceNamespace,
+			Package:                OdfDepsSubscriptionPackage,
+			Channel:                OdfDepsSubscriptionChannel,
+			StartingCSV:            OdfDepsSubscriptionStartingCSV,
+			InstallPlanApproval:    operatorv1alpha1.ApprovalAutomatic,
+		},
+	}
+
 	noobaaSubscription := &operatorv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      NoobaaSubscriptionName,
@@ -584,7 +600,7 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
-	return []*operatorv1alpha1.Subscription{ocsSubscription, rookSubscription, noobaaSubscription,
+	return []*operatorv1alpha1.Subscription{odfDepsSubscription, ocsSubscription, rookSubscription, noobaaSubscription,
 		csiAddonsSubscription, cephCsiSubscription, ocsClientSubscription, prometheusSubscription, recipeSubscription}
 }
 

--- a/pkg/util/readiness.go
+++ b/pkg/util/readiness.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 Red Hat OpenShift Data Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net/http"
+
+	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+func CheckCSVPhase(c client.Client, namespace string, csvNames ...string) healthz.Checker {
+	csvMap := map[string]struct{}{}
+	for _, name := range csvNames {
+		csvMap[name] = struct{}{}
+	}
+	return func(r *http.Request) error {
+		csvList := &opv1a1.ClusterServiceVersionList{}
+		if err := c.List(r.Context(), csvList, client.InNamespace(namespace)); err != nil {
+			return err
+		}
+		for idx := range csvList.Items {
+			csv := &csvList.Items[idx]
+			_, exists := csvMap[csv.Name]
+			if exists {
+				if csv.Status.Phase != opv1a1.CSVPhaseSucceeded {
+					return fmt.Errorf("CSV %s is not in Succeeded phase", csv.Name)
+				} else if csv.Status.Phase == opv1a1.CSVPhaseSucceeded {
+					delete(csvMap, csv.Name)
+				}
+			}
+		}
+		for csvName := range csvMap {
+			return fmt.Errorf("CSV %s is not found", csvName)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
odf-operator creates subscription for odf-dependencies and CRDs will become available once respective CSVs are present in the cluster. We check the phase of respective CSVs which are required for odf-op before becoming ready.

Depends on #503