### PR TITLE
controllers: Ensure console plugin creation after CSV verification

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -172,6 +172,14 @@ const (
 	OdfSubscriptionPackage = "odf-operator"
 )
 
+var (
+	EssentialCSVs = []string{
+		OcsSubscriptionStartingCSV,
+		RookSubscriptionStartingCSV,
+		NoobaaSubscriptionStartingCSV,
+	}
+)
+
 func GetEnvOrDefault(env string) string {
 	if val := os.Getenv(env); val != "" {
 		return val

--- a/controllers/subscription_controller.go
+++ b/controllers/subscription_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -289,6 +290,14 @@ func (r *SubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: sub.Name, Namespace: sub.Namespace}}}
 		},
 	)
+
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		odfDepsSub := GetStorageClusterSubscriptions()[0]
+		return EnsureDesiredSubscription(r.Client, odfDepsSub)
+	}))
+	if err != nil {
+		return err
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha1.Subscription{},

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -618,6 +618,8 @@ func GetStorageClusterSubscriptions() []*operatorv1alpha1.Subscription {
 		},
 	}
 
+	// Do not change the inxex of odfDepsSubscription. The 0 index is being used to create this subscription
+	// while starting in the subscription controller in SetupWithManager.
 	return []*operatorv1alpha1.Subscription{odfDepsSubscription, ocsSubscription, rookSubscription, noobaaSubscription,
 		csiAddonsSubscription, cephCsiSubscription, ocsClientSubscription, prometheusSubscription, recipeSubscription}
 }

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -30,6 +30,13 @@ import (
 	odfv1alpha1 "github.com/red-hat-storage/odf-operator/api/v1alpha1"
 )
 
+func TestSubscriptionIndex(t *testing.T) {
+	odfDepsSub := GetStorageClusterSubscriptions()[0]
+	msg := "odfDepsSub variable is expected to contain the 'odf-dependencies' subscription. " +
+		"Ensure the 'odf-dependencies' subscription indexed at 0."
+	assert.Equal(t, OdfDepsSubscriptionPackage, odfDepsSub.Spec.Package, msg)
+}
+
 func TestEnsureSubscription(t *testing.T) {
 
 	testCases := []struct {

--- a/main.go
+++ b/main.go
@@ -158,9 +158,10 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterVersionReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ConsolePort: odfConsolePort,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		ConsolePort:       odfConsolePort,
+		OperatorNamespace: operatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterVersion")
 		os.Exit(1)
@@ -176,17 +177,12 @@ func main() {
 	// can't check for only odf-dependencies CSV as OLM doesn't guarantee
 	// (based on observations) existence of all CRDs brought by OLM dependency
 	// mechanism.
-	csvsToBeSuceeded := []string{
-		controllers.OcsSubscriptionStartingCSV,
-		controllers.RookSubscriptionStartingCSV,
-		controllers.NoobaaSubscriptionStartingCSV,
-	}
 	if err := mgr.AddReadyzCheck(
 		"readyz",
 		util.CheckCSVPhase(
 			mgr.GetClient(),
 			operatorNamespace,
-			csvsToBeSuceeded...,
+			controllers.EssentialCSVs...,
 		),
 	); err != nil {
 		setupLog.Error(err, "unable to set up ready check")


### PR DESCRIPTION
Delay the creation of the console plugin until after verifying that the required CSVs are present. This ensures the necessary CRDs are present in the cluster, preventing UI errors like "Model does not exist."

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
