### PR TITLE
dockerfile: fix casing warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 WORKDIR /workspace
 

--- a/catalog.deps.Dockerfile
+++ b/catalog.deps.Dockerfile
@@ -1,5 +1,5 @@
 # The base image which contain rm and sed command
-FROM cirros as builder
+FROM cirros AS builder
 
 # Copy catalog files
 COPY catalog /configs


### PR DESCRIPTION
Docker requires consistent casing for keywords.
If a keyword is in uppercase, all keywords should be in uppercase. 
If a keyword is in lowercase, all keywords should be in lowercase.

The following warning appears while building images:

FromAsCasing: 'as' and 'FROM' keywords' casing do not match

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
