### PR TITLE
console: Always update console plugin proxy

### DIFF
--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -135,9 +135,7 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(clusterVersion string) er
 				odfConsolePlugin.Spec.Backend.Service.BasePath = basePath
 			}
 		}
-		if odfConsolePlugin.Spec.Proxy == nil {
-			odfConsolePlugin.Spec.Proxy = console.GetConsolePluginProxy(OperatorNamespace)
-		}
+		odfConsolePlugin.Spec.Proxy = console.GetConsolePluginProxy(OperatorNamespace)
 		return nil
 	})
 	if err != nil && !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
Remove the conditional check to ensure the console plugin proxy is always updated. This change addresses upgrade scenarios where the previous version had only two proxies, and a third (noobaa s3) one has now been added.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://issues.redhat.com/browse/DFBUGS-1830