### PR TITLE
controllers: add custom label to odf CSV to skip webhook call

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -66,6 +66,7 @@ metadata:
     support: Red Hat
     vendors.odf.openshift.io/kind: '["storagecluster.ocs.openshift.io/v1", "flashsystemcluster.odf.ibm.com/v1alpha1"]'
   labels:
+    odf.openshift.io/odf-operator: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported

--- a/config/manifests/bases/odf-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-operator.clusterserviceversion.yaml
@@ -33,6 +33,7 @@ metadata:
     support: Red Hat
     vendors.odf.openshift.io/kind: '["storagecluster.ocs.openshift.io/v1", "flashsystemcluster.odf.ibm.com/v1alpha1"]'
   labels:
+    odf.openshift.io/odf-operator: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported

--- a/controllers/webhook.go
+++ b/controllers/webhook.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	admrv1 "k8s.io/api/admissionregistration/v1"
@@ -158,7 +157,7 @@ func reconcileCsvMutatingWebhookConfiguration(ctx context.Context, cli client.Cl
 					Operator: metav1.LabelSelectorOpDoesNotExist,
 				},
 				{
-					Key:      fmt.Sprintf(CsvLabelKey, "odf-operator", operatorNamespace),
+					Key:      "odf.openshift.io/odf-operator",
 					Operator: metav1.LabelSelectorOpDoesNotExist,
 				},
 			},


### PR DESCRIPTION
Relying on the OLM label was unreliable as it gets added after CSV creation, causing the webhook to trigger for odf-operator CSV.

This change adds a custom label to ensure the webhook skips the odf-operator CSV during creation.

It prevents issues where uninstalling and reinstalling ODF blocks odf-operator CSV creation due to webhook CR presence in the cluster, while the odf-operator is absent to serve the webhook requests.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
