### PR TITLE
controllers: remove provider mode reference from odf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ e2e-test: ginkgo ## Run end to end functional tests.
 	@echo "build and run e2e tests"
 	./hack/e2e-test.sh
 
+# In external storageCluster there won't be any storageClient but CSI is managed by client op hence we need to
+# scale up client op based on cephCluster instead of storageClient CR
 define MAPPING
 apiVersion: v1
 kind: ConfigMap
@@ -97,6 +99,8 @@ data:
     channel: $(OCS_CLIENT_SUBSCRIPTION_CHANNEL)
     csv: $(OCS_CLIENT_SUBSCRIPTION_STARTINGCSV)
     pkg: $(OCS_CLIENT_SUBSCRIPTION_PACKAGE)
+    scaleUpOnInstanceOf:
+      - cephclusters.ceph.rook.io
   OCS: |
     channel: $(OCS_SUBSCRIPTION_CHANNEL)
     csv: $(OCS_SUBSCRIPTION_STARTINGCSV)

--- a/bundle/odf-operator/manifests/odf-operator-manager-config_v1_configmap.yaml
+++ b/bundle/odf-operator/manifests/odf-operator-manager-config_v1_configmap.yaml
@@ -58,6 +58,8 @@ data:
     channel: alpha
     csv: ocs-client-operator.v4.18.0
     pkg: ocs-client-operator
+    scaleUpOnInstanceOf:
+      - cephclusters.ceph.rook.io
   OCS_CLIENT_SUBSCRIPTION_CATALOGSOURCE: odf-catalogsource
   OCS_CLIENT_SUBSCRIPTION_CATALOGSOURCE_NAMESPACE: openshift-marketplace
   OCS_CLIENT_SUBSCRIPTION_CHANNEL: alpha

--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2025-03-25T10:54:38Z"
+    createdAt: "2025-03-25T13:13:23Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"

--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2025-03-21T05:24:31Z"
+    createdAt: "2025-03-25T10:54:38Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"
@@ -169,12 +169,6 @@ spec:
           - list
           - update
           - watch
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          verbs:
-          - delete
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/config/manager/mapping.yaml
+++ b/config/manager/mapping.yaml
@@ -31,6 +31,8 @@ data:
     channel: alpha
     csv: ocs-client-operator.v4.18.0
     pkg: ocs-client-operator
+    scaleUpOnInstanceOf:
+      - cephclusters.ceph.rook.io
   OCS: |
     channel: alpha
     csv: ocs-operator.v4.18.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,12 +27,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - delete
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/controllers/operatorscaler_controller.go
+++ b/controllers/operatorscaler_controller.go
@@ -63,11 +63,18 @@ var (
 			Kind:       "StorageCluster",
 			PkgNames:   []string{OcsSubscriptionPackage},
 		},
+		// In external storageCluster there won't be any storageClient but CSI is managed by client op hence we need to
+		// scale up client op based on cephCluster instead of storageClient CR
 		{
 			CrdName:    "cephclusters.ceph.rook.io",
 			ApiVersion: "ceph.rook.io/v1",
 			Kind:       "CephCluster",
-			PkgNames:   []string{RookSubscriptionPackage, CephCSISubscriptionPackage, CSIAddonsSubscriptionPackage},
+			PkgNames: []string{
+				RookSubscriptionPackage,
+				CephCSISubscriptionPackage,
+				CSIAddonsSubscriptionPackage,
+				OcsClientSubscriptionPackage,
+			},
 		},
 		{
 			CrdName:    "noobaas.noobaa.io",

--- a/controllers/subscription_controller.go
+++ b/controllers/subscription_controller.go
@@ -60,7 +60,6 @@ type SubscriptionReconciler struct {
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=operatorconditions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update
-//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=delete
 //+kubebuilder:rbac:groups=odf.openshift.io,resources=storagesystems,verbs=get;list;watch;create;update;patch;delete
 
 // For more details, check Reconcile and its Result here:


### PR DESCRIPTION
This PR ensures that we:

1. Always run client op from 4.19
2. Don't update the sub-channel for client-op, csi-add & csi-op


Ref: [RHSTOR-7170](https://issues.redhat.com/browse/RHSTOR-7170)