### PR TITLE
console: update compatibility support matrix for 4.19

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -145,7 +145,7 @@ func GetConsolePluginCR(consolePort int32, serviceNamespace string) *consolev1.C
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.19") {
+	if strings.Contains(clusterVersion, "4.20") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.19 supports OCP 4.19 and 4.20.