### PR TITLE
controllers: Reset struct before unmarshaling to prevent stale values

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	configMapIgnoreKeys = []string{"controller_manager_config.yaml"}
+	configMapIgnoreKeys             = []string{"controller_manager_config.yaml"}
+	EmptyOdfOperatorConfigMapRecord = OdfOperatorConfigMapRecord{}
 )
 
 type OdfOperatorConfigMapRecord struct {
@@ -83,6 +84,7 @@ func ParseOdfConfigMapRecords(logger logr.Logger, configmap corev1.ConfigMap, fn
 			continue
 		}
 
+		record = EmptyOdfOperatorConfigMapRecord
 		if err := yaml.Unmarshal([]byte(value), &record); err != nil {
 			logger.Error(err, "failed to unmarshal configmap data", "key", key)
 			continue


### PR DESCRIPTION
If the struct is not reset before unmarshaling, old values persist when new YAML data omits certain keys. This can lead to incorrect configurations being processed.

Now, record is explicitly reset to its zero state before each unmarshal operation, ensuring no leftover values from previous iterations affect the result.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
