### PR TITLE
controllers: fix upgrade deadlock in cleanup controller

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	OcsSubscriptionPackage     = "ocs-operator"
 	OdfSubscriptionPackage     = "odf-operator"
 	OdfDepsSubscriptionPackage = "odf-dependencies"
 )


### PR DESCRIPTION
During an ODF operator upgrade, a race condition occurs where:
- odf-operator upgrades first to 4.19 and removes the StorageSystem ownerReference from StorageCluster
- ocs-operator (still at v4.18) fails to find this ownerReference, marking itself as not upgradable

This creates a deadlock because:
- ocs-operator requires the StorageSystem ownerReference to mark itself upgradable
- odf-operator has already deleted both the ownerReference and StorageSystem CR

The fix ensures that ocs-operator CSV upgrades before running the cleanup, preventing this race condition.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>