### PR TITLE
controllers: add support for multiple namespaces

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -34,12 +34,14 @@ type OdfOperatorConfigMapRecord struct {
 	   channel: alpha
 	   csv: ocs-operator.v4.18.0
 	   pkg: ocs-operator
+	   namespace: openshift-storage
 	   scaleUpOnInstanceOf:
 	     - storageclusters.ocs.openshift.io
 	   ---------------------------------------
 	   channel: beta
 	   csv: odf-prometheus-operator.v4.18.0
 	   pkg: odf-prometheus-operator
+	   namespace: "" (empty will be treated as operator namespace)
 	   scaleUpOnInstanceOf:
 	     - alertmanagers.monitoring.coreos.com
 	     - prometheuses.monitoring.coreos.com
@@ -48,6 +50,7 @@ type OdfOperatorConfigMapRecord struct {
 	Channel             string   `yaml:"channel"`
 	Csv                 string   `yaml:"csv"`
 	Pkg                 string   `yaml:"pkg"`
+	Namespace           string   `yaml:"namespace"`
 	ScaleUpOnInstanceOf []string `yaml:"ScaleUpOnInstanceOf"`
 }
 
@@ -76,6 +79,10 @@ func ParseOdfConfigMapRecords(logger logr.Logger, configmap corev1.ConfigMap, fn
 		if err := yaml.Unmarshal([]byte(value), &record); err != nil {
 			logger.Error(err, "failed to unmarshal configmap data", "key", key)
 			continue
+		}
+
+		if record.Namespace == "" {
+			record.Namespace = OperatorNamespace
 		}
 
 		fn(&record, key, value)

--- a/controllers/operatorscaler_controller.go
+++ b/controllers/operatorscaler_controller.go
@@ -66,11 +66,13 @@ type KindCsvsRecord struct {
 	/* examples
 	   ApiVersion: "ceph.rook.io/v1",
 	   Kind:       "CephCluster",
+	   Namespace:  "openshift-storage",
 	   CsvNames:   []string{rook-operator.v0.0.1, cephcsi-operator.v0.0.1, csi-addons.v0.0.1, ocs-client-operator.v0.0.1},
 	*/
 
 	ApiVersion string
 	Kind       string
+	Namespace  string
 	CsvNames   []string
 }
 
@@ -152,6 +154,7 @@ func (r *OperatorScalerReconciler) loadOdfConfigMapData(ctx context.Context, log
 				rec = &KindCsvsRecord{}
 			}
 			rec.CsvNames = append(rec.CsvNames, record.Csv)
+			rec.Namespace = record.Namespace
 
 			// populate the apiVersion and kind
 			crd := &extv1.CustomResourceDefinition{}
@@ -269,7 +272,7 @@ func (r *OperatorScalerReconciler) reconcileOperators(ctx context.Context, logge
 
 				csv := &opv1a1.ClusterServiceVersion{}
 				csv.Name = csvName
-				csv.Namespace = OperatorNamespace
+				csv.Namespace = resourceMapping.Namespace
 				err = r.Client.Get(ctx, client.ObjectKeyFromObject(csv), csv)
 				if err != nil {
 					logger.Error(err, "failed getting csv ", "name", csvName)

--- a/controllers/subscription_controller.go
+++ b/controllers/subscription_controller.go
@@ -45,11 +45,13 @@ type OlmPkgRecord struct {
 	   channel: alpha
 	   csv: ocs-operator.v4.18.0
 	   pkg: ocs-operator
+	   namespace: openshift-storage
 	*/
 
-	Channel string `yaml:"channel"`
-	Csv     string `yaml:"csv"`
-	Pkg     string `yaml:"pkg"`
+	Channel   string `yaml:"channel"`
+	Csv       string `yaml:"csv"`
+	Pkg       string `yaml:"pkg"`
+	Namespace string `yaml:"namespace"`
 }
 
 type SubscriptionReconciler struct {
@@ -85,7 +87,9 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	if err := reconcileCsvWebhook(ctx, r.Client, logger, r.OperatorNamespace); err != nil {
+	targetNamespaces := getTargetNamespaces(olmPkgRecords)
+
+	if err := reconcileCsvWebhook(ctx, r.Client, logger, r.OperatorNamespace, targetNamespaces); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -95,6 +99,21 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 
 	logger.Info("reconcile completed successfully")
 	return ctrl.Result{}, nil
+}
+
+func getTargetNamespaces(olmPkgRecords []*OlmPkgRecord) []string {
+
+	var namespacesMap = make(map[string]bool)
+	var namespaces []string
+
+	for _, olmPkgRecord := range olmPkgRecords {
+		if !namespacesMap[olmPkgRecord.Namespace] {
+			namespaces = append(namespaces, olmPkgRecord.Namespace)
+		}
+		namespacesMap[olmPkgRecord.Namespace] = true
+	}
+
+	return namespaces
 }
 
 func (r *SubscriptionReconciler) loadOdfConfigMapData(ctx context.Context, logger logr.Logger, olmPkgRecords *[]*OlmPkgRecord, csvNamesMap map[string]struct{}) error {
@@ -111,9 +130,10 @@ func (r *SubscriptionReconciler) loadOdfConfigMapData(ctx context.Context, logge
 		}
 
 		*olmPkgRecords = append(*olmPkgRecords, &OlmPkgRecord{
-			Channel: record.Channel,
-			Csv:     record.Csv,
-			Pkg:     record.Pkg,
+			Channel:   record.Channel,
+			Csv:       record.Csv,
+			Pkg:       record.Pkg,
+			Namespace: record.Namespace,
 		})
 		csvNamesMap[record.Csv] = struct{}{}
 	})

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ func main() {
 	defaultNamespaces := map[string]cache.Config{
 		operatorNamespace:            {},
 		"openshift-storage-extended": {},
+		"ibm-spectrum-scale":         {},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/pkg/deploymanager/operatorscaler.go
+++ b/pkg/deploymanager/operatorscaler.go
@@ -34,7 +34,7 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 				"kind":       kindCsvRecord.Kind,
 				"metadata": map[string]any{
 					"name":      "test-obj",
-					"namespace": InstallNamespace,
+					"namespace": kindCsvRecord.Namespace,
 				},
 				// Add required spec fields here
 				"spec": map[string]any{
@@ -60,7 +60,7 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 
 		// Cleanup: Restore CSV replica to original state
 		//nolint:errcheck
-		defer d.ScaleDownCsvsDeploymentsReplicas(kindCsvRecord.CsvNames)
+		defer d.ScaleDownCsvsDeploymentsReplicas(kindCsvRecord.CsvNames, kindCsvRecord.Namespace)
 		d.Log.Info("cleanup", "csvs", kindCsvRecord.CsvNames)
 		// Cleanup: Delete the CR
 		//nolint:errcheck
@@ -73,7 +73,7 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 				return stderrors.Is(err, ErrDeploymentsNotScaledUp)
 			},
 			func() error {
-				if err := d.ValidateCsvsDeploymentsReplicasAreScaledUp(kindCsvRecord.CsvNames); err != nil {
+				if err := d.ValidateCsvsDeploymentsReplicasAreScaledUp(kindCsvRecord.CsvNames, kindCsvRecord.Namespace); err != nil {
 					d.Log.Error(err, "failed to validate csv deployment replicas")
 					return err
 				}
@@ -110,6 +110,7 @@ func (d *DeployManager) LoadOdfConfigMapData(kindMapping map[string]*controllers
 				rec = &controllers.KindCsvsRecord{}
 			}
 			rec.CsvNames = append(rec.CsvNames, record.Csv)
+			rec.Namespace = record.Namespace
 
 			// populate the apiVersion and kind
 			crd := &extv1.CustomResourceDefinition{}
@@ -134,11 +135,11 @@ func (d *DeployManager) LoadOdfConfigMapData(kindMapping map[string]*controllers
 	return combinedErr
 }
 
-func (d *DeployManager) ValidateCsvsDeploymentsReplicasAreScaledUp(csvNames []string) error {
+func (d *DeployManager) ValidateCsvsDeploymentsReplicasAreScaledUp(csvNames []string, namespace string) error {
 
 	for _, csvName := range csvNames {
 		csv := &opv1a1.ClusterServiceVersion{}
-		if err := d.Client.Get(d.Ctx, client.ObjectKey{Name: csvName, Namespace: InstallNamespace}, csv); err != nil {
+		if err := d.Client.Get(d.Ctx, client.ObjectKey{Name: csvName, Namespace: namespace}, csv); err != nil {
 			d.Log.Error(err, "failed to get the csv")
 			return err
 		}
@@ -157,13 +158,13 @@ func (d *DeployManager) ValidateCsvsDeploymentsReplicasAreScaledUp(csvNames []st
 	return nil
 }
 
-func (d *DeployManager) ScaleDownCsvsDeploymentsReplicas(csvNames []string) error {
+func (d *DeployManager) ScaleDownCsvsDeploymentsReplicas(csvNames []string, namespace string) error {
 
 	for _, csvName := range csvNames {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 
 			csv := &opv1a1.ClusterServiceVersion{}
-			if err := d.Client.Get(d.Ctx, client.ObjectKey{Name: csvName, Namespace: InstallNamespace}, csv); err != nil {
+			if err := d.Client.Get(d.Ctx, client.ObjectKey{Name: csvName, Namespace: namespace}, csv); err != nil {
 				d.Log.Error(err, "failed to get the csv")
 				return err
 			}

--- a/webhook/csv.go
+++ b/webhook/csv.go
@@ -165,10 +165,6 @@ func (r *ClusterServiceVersionDeploymentScaler) scaleDownCsvDeployments(logger l
 
 func (r *ClusterServiceVersionDeploymentScaler) isCsvManagedByOdf(csv *opv1a1.ClusterServiceVersion) bool {
 
-	if csv.Namespace != r.OperatorNamespace {
-		return false
-	}
-
 	return r.odfOwnedCsvNames[csv.Name]
 }
 


### PR DESCRIPTION
Previously, controllers handled only the operator namespace. This update enables handling multiple namespaces in the controllers.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>