### PR TITLE
[release-4.18] godeps: update ibm operator apis hash to fix cachito downstream builds

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IBM/ibm-storage-odf-operator v1.6.0 h1:1WmU3p4iO+ooyV46c8y2J4shXmh4QZNBYsDooWX4mJk=
-github.com/IBM/ibm-storage-odf-operator v1.6.0/go.mod h1:l4bsijv3oMv+M2i0S/C0GL9miAfloVMWG+IRFO1YyFo=
+github.com/IBM/ibm-storage-odf-operator v1.6.0 h1:ncfaf64VX6rxOgMqIJFHcrC/JBptsvklmcBSyto/qvM=
+github.com/IBM/ibm-storage-odf-operator v1.6.0/go.mod h1:lpZYtAcWTv9sPXEm4/E3vgYnDawbj2tDajkDwueO4QM=
 github.com/IBM/keyprotect-go-client v0.5.1/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/hack/make-project-vars.mk
+++ b/hack/make-project-vars.mk
@@ -5,7 +5,7 @@ ENVTEST_ASSETS_DIR := $(PROJECT_DIR)/testbin
 GOBIN ?= $(BIN_DIR)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-GOPROXY ?= direct,https://proxy.golang.org
+GOPROXY ?= https://proxy.golang.org/
 
 GO_LINT_IMG_LOCATION ?= golangci/golangci-lint
 GO_LINT_IMG_TAG ?= v1.49.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/IBM/ibm-storage-odf-operator v1.6.0
-## explicit; go 1.22.0
+## explicit; go 1.20
 github.com/IBM/ibm-storage-odf-operator/api/v1alpha1
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11


### PR DESCRIPTION
The previous direct hash in go.sum caused issues with cachito downstream builds. This commit updates the ibm-odf-operator-apis hash to resolve those caching problems.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>