### PR TITLE
DFBUGS-3719:[release-4.19] controllers: cache relevant CRDs only

### DIFF
--- a/controllers/operatorscaler_controller.go
+++ b/controllers/operatorscaler_controller.go
@@ -367,11 +367,11 @@ func (r *OperatorScalerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.GenerationChangedPredicate{},
 			),
 		).
+		// Watch only those CRDs whose names are listed in the ConfigMap, since the cache is limited to those CRDs in the main function.
 		Watches(
 			&extv1.CustomResourceDefinition{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(
-				//TODO: filter the crds we care about
 				// Trigger a reconcile only during the creation of a specific CRD to ensure it runs exactly once for that CRD.
 				// This is required to dynamically add a watch for the corresponding Custom Resource (CR) based on the CRD name.
 				// The reconcile will be triggered with the CRD name as `req.Name`, and the reconciler will set up a watch for the CR using the CRD name.


### PR DESCRIPTION
complete TODO to filter and cache only the CRDs we care about

caching all the crds gets into a situation where operator get oomkilled

Manual backport of #662

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>