### PR TITLE
controllers: update catalog source for all dependencies subscriptions

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	OdfSubscriptionPackage     = "odf-operator"
-	OdfDepsSubscriptionPackage = "odf-dependencies"
+	OdfSubscriptionPackage      = "odf-operator"
+	OdfDepsSubscriptionPackage  = "odf-dependencies"
+	CnsaDepsSubscriptionPackage = "cnsa-dependencies"
 )
 
 var (

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -102,10 +102,12 @@ func GetDesiredSubscription(ctx context.Context, cli client.Client, record *OlmP
 	}
 
 	if !subExsist {
-		// Set the catalog source for the odf-dependencies subscription to match that of the odf-operator subscription
-		// This ensures that the odf-dependencies subscription uses the same catalog source across all environments,
+		// Set the catalog source for the dependencies subscription to match that of the odf-operator subscription
+		// This ensures that the dependencies subscription uses the same catalog source across all environments,
 		// including offline and test environments where the catalog name may vary.
-		if desiredSubscription.Spec.Package == OdfDepsSubscriptionPackage {
+		if desiredSubscription.Spec.Package == OdfDepsSubscriptionPackage ||
+			desiredSubscription.Spec.Package == CnsaDepsSubscriptionPackage {
+
 			desiredSubscription.Spec.CatalogSource = odfSub.Spec.CatalogSource
 			desiredSubscription.Spec.CatalogSourceNamespace = odfSub.Spec.CatalogSourceNamespace
 		}

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"go.uber.org/multierr"
@@ -191,16 +190,17 @@ func EnsureDesiredSubscription(ctx context.Context, cli client.Client, olmPkgRec
 		return err
 	}
 
-	isDependenciesPkg := strings.HasSuffix(desiredSubscription.Spec.Package, "-dependencies")
+	isDependenciesPkg := desiredSubscription.Spec.Package == OdfDepsSubscriptionPackage ||
+		desiredSubscription.Spec.Package == CnsaDepsSubscriptionPackage
 
-	// Do not reconcile any other "*-dependencies" subscriptions under Red Hat,
+	// Do not reconcile any other "dependencies" subscriptions under Red Hat, other than odf-dependencies
 	if providerName == providerNameRedHat &&
 		isDependenciesPkg &&
 		desiredSubscription.Spec.Package != OdfDepsSubscriptionPackage {
 		return nil
 	}
 
-	// Skip creating (only update) subscriptions other than *-dependencies
+	// Skip creating (only update) subscriptions other than "dependencies"
 	// It will allow OLM to manage their creation via dependency resolution
 	if !isDependenciesPkg && desiredSubscription.CreationTimestamp.IsZero() {
 		return nil


### PR DESCRIPTION
Previously, we only updated the catalog source for the odf-dependencies subscription. This change extends the logic to update the catalog source for odf-dependencies as well as cnsa-dependencies subscription.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
