### PR TITLE
controllers: use a list for dependency packages checks

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -28,6 +28,13 @@ const (
 )
 
 var (
+	DepsSubscriptionPackageNames = []string{
+		OdfDepsSubscriptionPackage,
+		CnsaDepsSubscriptionPackage,
+	}
+)
+
+var (
 	OperatorNamespace        string
 	odfOperatorConfigMapName string
 )

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -104,9 +104,7 @@ func GetDesiredSubscription(ctx context.Context, cli client.Client, record *OlmP
 		// Set the catalog source for the dependencies subscription to match that of the odf-operator subscription
 		// This ensures that the dependencies subscription uses the same catalog source across all environments,
 		// including offline and test environments where the catalog name may vary.
-		if desiredSubscription.Spec.Package == OdfDepsSubscriptionPackage ||
-			desiredSubscription.Spec.Package == CnsaDepsSubscriptionPackage {
-
+		if slices.Contains(DepsSubscriptionPackageNames, desiredSubscription.Spec.Package) {
 			desiredSubscription.Spec.CatalogSource = odfSub.Spec.CatalogSource
 			desiredSubscription.Spec.CatalogSourceNamespace = odfSub.Spec.CatalogSourceNamespace
 		}
@@ -190,8 +188,7 @@ func EnsureDesiredSubscription(ctx context.Context, cli client.Client, olmPkgRec
 		return err
 	}
 
-	isDependenciesPkg := desiredSubscription.Spec.Package == OdfDepsSubscriptionPackage ||
-		desiredSubscription.Spec.Package == CnsaDepsSubscriptionPackage
+	isDependenciesPkg := slices.Contains(DepsSubscriptionPackageNames, desiredSubscription.Spec.Package)
 
 	// Do not reconcile any other "dependencies" subscriptions under Red Hat, other than odf-dependencies
 	if providerName == providerNameRedHat &&


### PR DESCRIPTION
Replace hardcoded checks with a shared list.

Consolidate dependency package names into a single list and replace manual equality checks with slices.Contains. This improves readability, maintainability, and reduces the chance of bugs when updating package names.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
