### PR TITLE
makefile: add target to generate additional FDF dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,20 @@ update-mgr-config: ## Feed env variables to the manager configmap
 	@echo "$$DEPLOYMENT_ENV_PATCH" > config/manager/deployment-env-patch.yaml
 	@echo "$$CONFIGMAP_YAML" > config/manager/configmap.yaml
 
+# ------------------------------------------------------------------------------
+# This target prints additional FDF dependencies. This will be used in the DS build process.
+#
+# IMPORTANT:
+# - Printing should only be enabled once the Fusion is available for the target OCP/ODF release.
+#
+# HOW TO CONTROL PRINTING:
+# - To enable printing, set the IS_FUSION_PRESENT=true.
+# - To disable printing, set the IS_FUSION_PRESENT=false.
+# ------------------------------------------------------------------------------
+IS_FUSION_PRESENT=true
+gen-additional-fdf-dependencies:
+	@[ "$(IS_FUSION_PRESENT)" = "true" ] && echo "$$ADDITIONAL_FDF_DEPENDENCIES_YAML" || true
+
 ##@ Build
 
 build: generate fmt vet go-build ## Build manager binary.

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -144,6 +144,16 @@ endef
 export ODF_DEPENDENCIES_YAML
 
 
+# This will be used to add these dependencies in the fdf DS build
+define ADDITIONAL_FDF_DEPENDENCIES_YAML
+- type: olm.package
+  value:
+    packageName: $(IBM_ODF_SUBSCRIPTION_PACKAGE)
+    version: "$(subst v,,$(IBM_ODF_BUNDLE_VERSION))"
+endef
+export ADDITIONAL_FDF_DEPENDENCIES_YAML
+
+
 define CNSA_DEPENDENCIES_YAML
 dependencies:
 endef


### PR DESCRIPTION
Introduce a new make target `gen-additional-fdf-dependencies` that outputs extra dependencies required only for FDF. These will be used later in the FDF DS build process.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://issues.redhat.com/browse/DFBUGS-3629