### PR TITLE
Propagate ODF OperatorCondition CR overrides to the dependent operators [wip]

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2025-10-09T10:25:19Z"
+    createdAt: "2025-10-16T11:51:56Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"
@@ -296,6 +296,8 @@ spec:
           verbs:
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - operators.coreos.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -207,6 +207,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - operators.coreos.com


### PR DESCRIPTION
This enables a user of ODF to override all the upgrade statuses of the dependent operators at one place.
Ref-https://issues.redhat.com/browse/RHSTOR-7756