### PR TITLE
Improve OpenShift version detection logic

### DIFF
--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -55,11 +55,11 @@ type ClusterVersionReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	instance := configv1.ClusterVersion{}
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	ocpVersion, err := util.GetOpenShiftVersion(ctx, r.Client)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.ensureConsolePlugin(ctx, instance.Status.Desired.Version); err != nil {
+	if err := r.ensureConsolePlugin(ctx, ocpVersion); err != nil {
 		logger.Error(err, "Could not ensure compatibility for ODF consolePlugin")
 		return ctrl.Result{}, err
 	}
@@ -75,7 +75,7 @@ func (r *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		clusterVersion, err := util.DetermineOpenShiftVersion(ctx, r.Client)
+		clusterVersion, err := util.GetOpenShiftVersion(ctx, r.Client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The clusterVersion CR has openshift version in 2 places,
- Status.Desired.Version
- Status.History[].Version 
During a version upgrade, the desired version is updated first although the upgrade is not yet completed, and the upgrade may not complete ever in some cases. So the true version is the latest completed version in 
the history. Also in practice there is only one cluster version CR with name "version", hence no need to do a list.