### PR TITLE
bundle: remove cnsa related config from the configmap

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.20.0_v1_configmap.yaml
+++ b/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.20.0_v1_configmap.yaml
@@ -6,18 +6,6 @@ data:
     pkg: cephcsi-operator
     scaleUpOnInstanceOf:
       - cephclusters.ceph.rook.io
-  CNSA: |
-    channel: beta
-    csv: ibm-spectrum-scale-operator.v60.0.0
-    pkg: ibm-spectrum-scale-operator
-    namespace: ibm-spectrum-scale
-    scaleUpOnInstanceOf:
-      - clusters.scale.spectrum.ibm.com
-  CNSA_DEPS: |
-    channel: alpha
-    csv: cnsa-dependencies.v4.20.0
-    pkg: cnsa-dependencies
-    namespace: ibm-spectrum-scale
   CSIADDONS: |
     channel: alpha
     csv: csi-addons.v0.13.0

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -55,18 +55,6 @@ data:
     channel: alpha
     csv: odf-dependencies.v4.20.0
     pkg: odf-dependencies
-  CNSA_DEPS: |
-    channel: alpha
-    csv: cnsa-dependencies.v4.20.0
-    pkg: cnsa-dependencies
-    namespace: ibm-spectrum-scale
-  CNSA: |
-    channel: beta
-    csv: ibm-spectrum-scale-operator.v60.0.0
-    pkg: ibm-spectrum-scale-operator
-    namespace: ibm-spectrum-scale
-    scaleUpOnInstanceOf:
-      - clusters.scale.spectrum.ibm.com
   PROMETHEUS: |
     channel: beta
     csv: odf-prometheus-operator.v4.20.0

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -76,18 +76,6 @@ data:
     channel: $(ODF_DEPS_SUBSCRIPTION_CHANNEL)
     csv: $(ODF_DEPS_SUBSCRIPTION_CSVNAME)
     pkg: $(ODF_DEPS_SUBSCRIPTION_PACKAGE)
-  CNSA_DEPS: |
-    channel: $(CNSA_DEPS_SUBSCRIPTION_CHANNEL)
-    csv: $(CNSA_DEPS_SUBSCRIPTION_CSVNAME)
-    pkg: $(CNSA_DEPS_SUBSCRIPTION_PACKAGE)
-    namespace: ibm-spectrum-scale
-  CNSA: |
-    channel: $(CNSA_SUBSCRIPTION_CHANNEL)
-    csv: $(CNSA_SUBSCRIPTION_CSVNAME)
-    pkg: $(CNSA_SUBSCRIPTION_PACKAGE)
-    namespace: ibm-spectrum-scale
-    scaleUpOnInstanceOf:
-      - clusters.scale.spectrum.ibm.com
   PROMETHEUS: |
     channel: $(PROMETHEUS_SUBSCRIPTION_CHANNEL)
     csv: $(PROMETHEUS_SUBSCRIPTION_CSVNAME)


### PR DESCRIPTION
There are concerns about CNSA being deployed twice, once by Fusion and
once by FDF. To avoid this conflict, we are removing all CNSA-related
configuration and disabling automatic deployment/management of CNSA.

For the dev preview, CNSA will need to be installed manually following
documented steps. We will restore the automated installation once the
migration work is complete.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://issues.redhat.com/browse/DFBUGS-4699