### PR TITLE
Revert "bundle: remove CNSA related configuration from the ConfigMap"

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.20.0_v1_configmap.yaml
+++ b/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.20.0_v1_configmap.yaml
@@ -6,6 +6,18 @@ data:
     pkg: cephcsi-operator
     scaleUpOnInstanceOf:
       - cephclusters.ceph.rook.io
+  CNSA: |
+    channel: beta
+    csv: ibm-spectrum-scale-operator.v60.0.0
+    pkg: ibm-spectrum-scale-operator
+    namespace: ibm-spectrum-scale
+    scaleUpOnInstanceOf:
+      - clusters.scale.spectrum.ibm.com
+  CNSA_DEPS: |
+    channel: alpha
+    csv: cnsa-dependencies.v4.20.0
+    pkg: cnsa-dependencies
+    namespace: ibm-spectrum-scale
   CSIADDONS: |
     channel: alpha
     csv: csi-addons.v0.13.0

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -55,6 +55,18 @@ data:
     channel: alpha
     csv: odf-dependencies.v4.20.0
     pkg: odf-dependencies
+  CNSA_DEPS: |
+    channel: alpha
+    csv: cnsa-dependencies.v4.20.0
+    pkg: cnsa-dependencies
+    namespace: ibm-spectrum-scale
+  CNSA: |
+    channel: beta
+    csv: ibm-spectrum-scale-operator.v60.0.0
+    pkg: ibm-spectrum-scale-operator
+    namespace: ibm-spectrum-scale
+    scaleUpOnInstanceOf:
+      - clusters.scale.spectrum.ibm.com
   PROMETHEUS: |
     channel: beta
     csv: odf-prometheus-operator.v4.20.0

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -76,6 +76,18 @@ data:
     channel: $(ODF_DEPS_SUBSCRIPTION_CHANNEL)
     csv: $(ODF_DEPS_SUBSCRIPTION_CSVNAME)
     pkg: $(ODF_DEPS_SUBSCRIPTION_PACKAGE)
+  CNSA_DEPS: |
+    channel: $(CNSA_DEPS_SUBSCRIPTION_CHANNEL)
+    csv: $(CNSA_DEPS_SUBSCRIPTION_CSVNAME)
+    pkg: $(CNSA_DEPS_SUBSCRIPTION_PACKAGE)
+    namespace: ibm-spectrum-scale
+  CNSA: |
+    channel: $(CNSA_SUBSCRIPTION_CHANNEL)
+    csv: $(CNSA_SUBSCRIPTION_CSVNAME)
+    pkg: $(CNSA_SUBSCRIPTION_PACKAGE)
+    namespace: ibm-spectrum-scale
+    scaleUpOnInstanceOf:
+      - clusters.scale.spectrum.ibm.com
   PROMETHEUS: |
     channel: $(PROMETHEUS_SUBSCRIPTION_CHANNEL)
     csv: $(PROMETHEUS_SUBSCRIPTION_CSVNAME)


### PR DESCRIPTION
This reverts commit 039bdf21a43078f035b8684a353b24bcc60bb4c0.

Reintroduce CNSA in release 4.21

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
