### PR TITLE
bundle: add arm64 label in the CI

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -27,6 +27,7 @@ metadata:
   labels:
     odf.openshift.io/odf-operator: "true"
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: odf-operator.v4.20.0

--- a/config/manifests/bases/odf-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-operator.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
   labels:
     odf.openshift.io/odf-operator: "true"
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: odf-operator.v0.0.0


### PR DESCRIPTION
We have started buidling arm64 builds. Add a label to filter it in UI for arm64.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://issues.redhat.com/browse/DFBUGS-4779
