### PR TITLE
bundle: increase memory limit to 400Mi

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -390,10 +390,10 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 300Mi
+                    memory: 400Mi
                   requests:
                     cpu: 200m
-                    memory: 200Mi
+                    memory: 400Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,10 +68,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 300Mi
+            memory: 400Mi
           requests:
             cpu: 200m
-            memory: 200Mi
+            memory: 400Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION
Observed occasional memory spikes causing the pod to be OOMKilled. Increasing the memory limit to provide better stability.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://issues.redhat.com/browse/DFBUGS-4011