### PR TITLE
Move ux-backend deployment to odf-operator

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-console"]'
     containerImage: quay.io/ocs-dev/odf-operator:latest
-    createdAt: "2025-10-09T10:25:19Z"
+    createdAt: "2025-12-10T13:13:32Z"
     description: OpenShift Data Foundation provides a common control plane for storage
       solutions on OpenShift Container Platform.
     features.operators.openshift.io/token-auth-aws: "true"
@@ -114,6 +114,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - secrets
           - services
           verbs:
           - create
@@ -358,6 +359,15 @@ spec:
                 env:
                 - name: PKGS_CONFIG_MAP_NAME
                   value: odf-operator-pkgs-config-4.20.0
+                - name: UX_BACKEND_SERVER_IMAGE
+                  value: quay.io/ocs-dev/ocs-operator:latest
+                - name: UX_BACKEND_OAUTH_IMAGE
+                  value: quay.io/openshift/origin-oauth-proxy:4.20.0
+                - name: DEVICEFINDER_IMAGE
+                  value: quay.io/ocs-dev/ocs-devicefinder:latest
+                - name: ONBOARDING_TOKEN_LIFETIME
+                - name: UX_BACKEND_PORT
+                - name: TLS_ENABLED
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/deployment-env-patch.yaml
+++ b/config/manager/deployment-env-patch.yaml
@@ -11,3 +11,12 @@ spec:
         env:
         - name: PKGS_CONFIG_MAP_NAME
           value: odf-operator-pkgs-config-4.20.0
+        - name: UX_BACKEND_SERVER_IMAGE
+          value: quay.io/ocs-dev/ocs-operator:latest
+        - name: UX_BACKEND_OAUTH_IMAGE
+          value: quay.io/openshift/origin-oauth-proxy:4.20.0
+        - name: DEVICEFINDER_IMAGE
+          value: quay.io/ocs-dev/ocs-devicefinder:latest
+        - name: ONBOARDING_TOKEN_LIFETIME
+        - name: UX_BACKEND_PORT
+        - name: TLS_ENABLED

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
   - services
   verbs:
   - create

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -19,16 +19,23 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/red-hat-storage/odf-operator/console"
 	"github.com/red-hat-storage/odf-operator/pkg/util"
@@ -47,6 +54,7 @@ type ClusterVersionReconciler struct {
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="apps",resources=deployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;create;update
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=get;list;create;update;delete
@@ -61,6 +69,11 @@ func (r *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	if err := r.ensureConsolePlugin(ctx, ocpVersion); err != nil {
 		logger.Error(err, "Could not ensure compatibility for ODF consolePlugin")
+		return ctrl.Result{}, err
+	}
+
+	if err := r.ensureUXBackendServer(ctx); err != nil {
+		logger.Error(err, "Could not ensure UX backend server")
 		return ctrl.Result{}, err
 	}
 
@@ -86,8 +99,29 @@ func (r *ClusterVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	uxBackendResourcePredicate := func(name string) predicate.Predicate {
+		return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetName() == name && obj.GetNamespace() == OperatorNamespace
+		})
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configv1.ClusterVersion{}).
+		Watches(
+			&appsv1.Deployment{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(uxBackendResourcePredicate("ux-backend-server")),
+		).
+		Watches(
+			&corev1.Secret{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(uxBackendResourcePredicate("ux-backend-proxy")),
+		).
+		Watches(
+			&corev1.Service{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(uxBackendResourcePredicate("ux-backend-proxy")),
+		).
 		Complete(r)
 }
 
@@ -162,6 +196,72 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(ctx context.Context, clus
 	})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
+	}
+
+	return nil
+}
+
+func (r *ClusterVersionReconciler) ensureUXBackendServer(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	odfCsvName, err := util.GetConditionName(r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get ODF CSV name: %w", err)
+	}
+
+	odfCsv := &opv1a1.ClusterServiceVersion{}
+	odfCsv.Name = odfCsvName
+	odfCsv.Namespace = OperatorNamespace
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(odfCsv), odfCsv); err != nil {
+		return fmt.Errorf("failed to get ODF CSV %s/%s: %w", odfCsv.Namespace, odfCsv.Name, err)
+	}
+
+	// TODO: remove the following check in future version
+	// the following is to check if ocs-operator and odf-operator csvs are at same version
+	ocsCsvName := strings.ReplaceAll(odfCsvName, "odf", "ocs")
+	ocsCSV := &opv1a1.ClusterServiceVersion{}
+	ocsCSV.Name = ocsCsvName
+	ocsCSV.Namespace = OperatorNamespace
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(ocsCSV), ocsCSV); err != nil {
+		// Return nil to exit early. The OCS operator CSV must match the ODF operator CSV version,
+		// this is because the ux-backend-server deployment is moved from ocs-operator to odf-operator
+		// during upgrade there may be a collision of ownership between the two operators
+		return nil
+	}
+
+	logger.Info("Ensuring UX backend server secret")
+	uxBackendServerSecret := getUXBackendServerSecret()
+	secretData := uxBackendServerSecret.StringData
+	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, uxBackendServerSecret, func() error {
+		uxBackendServerSecret.SetOwnerReferences(nil)
+		uxBackendServerSecret.StringData = secretData
+		return controllerutil.SetControllerReference(odfCsv, uxBackendServerSecret, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("failed to create or update UX backend server secret: %w", err)
+	}
+
+	logger.Info("Ensuring UX backend server service")
+	uxBackendServerService := getUXBackendServerService()
+	desiredService := uxBackendServerService.Spec.DeepCopy()
+	annotations := uxBackendServerService.Annotations
+	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, uxBackendServerService, func() error {
+		uxBackendServerService.SetOwnerReferences(nil)
+		uxBackendServerService.Spec = *desiredService
+		uxBackendServerService.Annotations = annotations
+		return controllerutil.SetControllerReference(odfCsv, uxBackendServerService, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("failed to create or update UX backend server service: %w", err)
+	}
+
+	// Create/Update UX backend server deployment
+	logger.Info("Ensuring UX backend server deployment")
+	uxBackendServerDeployment := getUXBackendServerDeployment()
+	desiredSpec := uxBackendServerDeployment.Spec.DeepCopy()
+	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, uxBackendServerDeployment, func() error {
+		uxBackendServerDeployment.SetOwnerReferences(nil)
+		uxBackendServerDeployment.Spec = *desiredSpec
+		return controllerutil.SetControllerReference(odfCsv, uxBackendServerDeployment, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("failed to create or update UX backend server deployment: %w", err)
 	}
 
 	return nil

--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -1,0 +1,204 @@
+package controllers
+
+import (
+	"os"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	random30CharacterString = "KP7TThmSTZegSGmHuPKLnSaaAHSG3RSgqw6akBj0oVk"
+)
+
+func getUXBackendServerDeployment() *appsv1.Deployment {
+
+	labels := map[string]string{
+		"app.kubernetes.io/component": "ux-backend-server",
+		"app.kubernetes.io/name":      "ux-backend-server",
+		"app":                         "ux-backend-server",
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ux-backend-server",
+			Namespace: OperatorNamespace,
+			Labels:    labels,
+		},
+	}
+	deploymentSpec := &appsv1.DeploymentSpec{
+		Replicas: ptr.To(int32(1)),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: labels,
+		},
+		Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ux-backend-server",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "onboarding-private-key",
+								MountPath: "/etc/private-key",
+							},
+							{
+								Name:      "ux-cert-secret",
+								MountPath: "/etc/tls/private",
+							},
+						},
+						Image:           os.Getenv("UX_BACKEND_SERVER_IMAGE"),
+						ImagePullPolicy: "IfNotPresent",
+						Command:         []string{"/usr/local/bin/ux-backend-server"},
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 8080,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "ONBOARDING_TOKEN_LIFETIME",
+								Value: os.Getenv("ONBOARDING_TOKEN_LIFETIME"),
+							},
+							{
+								Name:  "UX_BACKEND_PORT",
+								Value: os.Getenv("UX_BACKEND_PORT"),
+							},
+							{
+								Name:  "TLS_ENABLED",
+								Value: os.Getenv("TLS_ENABLED"),
+							},
+							{
+								Name:  "DEVICEFINDER_IMAGE",
+								Value: os.Getenv("DEVICEFINDER_IMAGE"),
+							},
+							{
+								Name: "POD_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:           ptr.To(true),
+							ReadOnlyRootFilesystem: ptr.To(true),
+						},
+					},
+					{
+						Name: "oauth-proxy",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "ux-proxy-secret",
+								MountPath: "/etc/proxy/secrets",
+							},
+							{
+								Name:      "ux-cert-secret",
+								MountPath: "/etc/tls/private",
+							},
+						},
+						Image:           os.Getenv("UX_BACKEND_OAUTH_IMAGE"),
+						ImagePullPolicy: "IfNotPresent",
+						Args: []string{"-provider=openshift",
+							"-https-address=:8888",
+							"-http-address=", "-email-domain=*",
+							"-upstream=http://localhost:8080/",
+							"-tls-cert=/etc/tls/private/tls.crt",
+							"-tls-key=/etc/tls/private/tls.key",
+							"-cookie-secret-file=/etc/proxy/secrets/session_secret",
+							"-openshift-service-account=ux-backend-server",
+							`-openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"}}`,
+							"-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 8888,
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:           ptr.To(true),
+							ReadOnlyRootFilesystem: ptr.To(true),
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "onboarding-private-key",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "onboarding-private-key",
+								Optional:   ptr.To(true),
+							},
+						},
+					},
+					{
+						Name: "ux-proxy-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "ux-backend-proxy",
+							},
+						},
+					},
+					{
+						Name: "ux-cert-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "ux-cert-secret",
+							},
+						},
+					},
+				},
+				PriorityClassName:  "system-cluster-critical",
+				ServiceAccountName: "ux-backend-server",
+			},
+		},
+	}
+
+	deployment.Spec = *deploymentSpec
+	return deployment
+}
+
+func getUXBackendServerSecret() *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ux-backend-proxy",
+			Namespace: OperatorNamespace,
+		},
+	}
+	secret.StringData = map[string]string{
+		"session_secret": random30CharacterString,
+	}
+	return secret
+}
+
+func getUXBackendServerService() *corev1.Service {
+	service := &corev1.Service{}
+	service.Name = "ux-backend-proxy"
+	service.Namespace = OperatorNamespace
+	service.Annotations = map[string]string{
+		"service.beta.openshift.io/serving-cert-secret-name": "ux-cert-secret",
+	}
+	service.Spec = corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{
+			{
+				Name:     "proxy",
+				Port:     8888,
+				Protocol: corev1.ProtocolTCP,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8888,
+				},
+			},
+		},
+		Selector:        map[string]string{"app": "ux-backend-server"},
+		SessionAffinity: "None",
+		Type:            "ClusterIP",
+	}
+	return service
+}

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -83,6 +83,9 @@ endif
 OPERATOR_NAMESPACE ?= openshift-storage
 
 ODF_CONSOLE_IMG ?= quay.io/ocs-dev/odf-console:latest
+UX_BACKEND_SERVER_IMAGE ?= quay.io/ocs-dev/ocs-operator:latest
+UX_BACKEND_OAUTH_IMAGE ?= quay.io/openshift/origin-oauth-proxy:4.20.0
+DEVICEFINDER_IMAGE ?= quay.io/ocs-dev/ocs-devicefinder:latest
 
 ODF_DEPS_SUBSCRIPTION_PACKAGE ?= $(ODF_DEPS_BUNDLE_NAME)
 ODF_DEPS_SUBSCRIPTION_CHANNEL ?= $(DEFAULT_CHANNEL)

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -12,6 +12,15 @@ spec:
         env:
         - name: PKGS_CONFIG_MAP_NAME
           value: odf-operator-pkgs-config-$(VERSION)
+        - name: UX_BACKEND_SERVER_IMAGE
+          value: $(UX_BACKEND_SERVER_IMAGE)
+        - name: UX_BACKEND_OAUTH_IMAGE
+          value: $(UX_BACKEND_OAUTH_IMAGE)
+        - name: DEVICEFINDER_IMAGE
+          value: $(DEVICEFINDER_IMAGE)
+        - name: ONBOARDING_TOKEN_LIFETIME
+        - name: UX_BACKEND_PORT
+        - name: TLS_ENABLED
 endef
 export DEPLOYMENT_ENV_PATCH
 


### PR DESCRIPTION
The device discovery changes in ocs-operator require ux-backend to be running, but today the deployment of ux-backend is handled by ocs-operator which doen't come up  unless storagecluster CR is created.

CNSA should be independent of storageCluster CR, so moving the deployment of ux-backend to odf-operator.
https://issues.redhat.com/browse/RHSTOR-8138