### PR TITLE
Fix authenticated endpoint (ux-backend-server)

### DIFF
--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -125,7 +125,7 @@ func getUXBackendServerDeployment() *appsv1.Deployment {
 							"-tls-key=/etc/tls/private/tls.key",
 							"-cookie-secret-file=/etc/proxy/secrets/session_secret",
 							"-openshift-service-account=ux-backend-server",
-							`-openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"}}`,
+							`-openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"},"/info/":{"group":"authorization.k8s.io","resource":"selfsubjectaccessreviews","verb":"create"}}`,
 							"-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
 						Ports: []corev1.ContainerPort{
 							{


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-5272

A new authenticated endpoint was added for the non-admin ODF user to ux-backend-server (behind kube-rbac-proxy) in PR https://github.com/red-hat-storage/ocs-operator/pull/3536. But seems like we migrated the server deployment from OCS to ODF in https://github.com/red-hat-storage/odf-operator/pull/711 and this new path was missed from the `-openshift-delegate-urls` allowlist. As a result, the proxy does not delegate requests for this endpoint.