### PR TITLE
controllers: approve InstallPlans only in RequiresApproval phase

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -331,6 +331,7 @@ func ApproveInstallPlanForCsv(ctx context.Context, cli client.Client, csvName st
 		if slices.Contains(installPlan.Spec.ClusterServiceVersionNames, csvName) {
 			foundInstallPlan = true
 			if installPlan.Spec.Approval == opv1a1.ApprovalManual &&
+				installPlan.Status.Phase == opv1a1.InstallPlanPhaseRequiresApproval &&
 				!installPlan.Spec.Approved {
 
 				installPlans.Items[i].Spec.Approved = true


### PR DESCRIPTION
Approve InstallPlans only after OLM reaches RequiresApproval

OLM creates an initial InstallPlan that was approved immediately by the ODF operator while OLM was still processing it. OLM then detected the change as a modification conflict, treated the InstallPlan as invalid, and created a second duplicate InstallPlan. Subscriptions were updated to point to the new InstallPlan, which remained unapproved and caused upgrades to get stuck in UpgradePending.

To prevent this, InstallPlans are now approved only after they reach the RequiresApproval phase, indicating that OLM has finished processing and is explicitly waiting for an external approver. This avoids the conflict, prevents duplicate InstallPlans, and ensures upgrades complete successfully.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

More info regarding this change can be found in JIRA where this change was suggested by `Kursad Yildirim`: https://issues.redhat.com/browse/DFBUGS-5327