### PR TITLE
action: expand go version list to run tests on go 1.26 as well

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25"]
+        go: ["1.25", "1.26"]
     steps:
     - uses: actions/setup-go@v5
       with:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25"]
+        go: ["1.25", "1.26"]
     steps:
     - uses: actions/setup-go@v5
       with:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25"]
+        go: ["1.25", "1.26"]
     steps:
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25"]
+        go: ["1.25", "1.26"]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
