### PR TITLE
test: increase timeout from 5m to 8m

### DIFF
--- a/hack/install-odf.sh
+++ b/hack/install-odf.sh
@@ -63,7 +63,7 @@ done
 
 oc wait --timeout=5m --for jsonpath='{.status.phase}'=Succeeded -n "$INSTALL_NAMESPACE" csv $CSV_NAMES
 
-oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment \
+oc wait --timeout=8m --for condition=Available -n "$INSTALL_NAMESPACE" deployment \
     ceph-csi-controller-manager \
     csi-addons-controller-manager \
     noobaa-operator \


### PR DESCRIPTION
Previously, ux-backend-server was part of the CSV, but it is now managed by the controller, which takes additional time to become ready. The existing 5m timeout is insufficient, so it is increased to 8m.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
