### PR TITLE
makefile: update scaleUp CR references for CSVs

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.22.0_v1_configmap.yaml
+++ b/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.22.0_v1_configmap.yaml
@@ -5,7 +5,7 @@ data:
     csv: cephcsi-operator.v4.22.0
     pkg: cephcsi-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - operatorconfigs.csi.ceph.io
   CNSA: |
     channel: stable-v60.1
     csv: ibm-spectrum-scale-operator.v60.1.0
@@ -23,7 +23,7 @@ data:
     csv: csi-addons.v0.14.0
     pkg: csi-addons
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - csiaddonsnodes.csiaddons.openshift.io
   IBM_CSI: |
     channel: stable-v1.12.4
     csv: ibm-block-csi-operator.v1.12.4
@@ -53,7 +53,7 @@ data:
     csv: ocs-client-operator.v4.22.0
     pkg: ocs-client-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - storageclients.ocs.openshift.io
   ODF_DEPS: |
     channel: alpha
     csv: odf-dependencies.v4.22.0
@@ -80,7 +80,7 @@ data:
     csv: odf-external-snapshotter-operator.v4.22.0
     pkg: odf-external-snapshotter-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io
 kind: ConfigMap
 metadata:
   name: odf-operator-pkgs-config-4.22.0

--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -224,6 +224,30 @@ spec:
           - list
           - update
         - apiGroups:
+          - csi.ceph.io
+          resources:
+          - operatorconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - csiaddons.openshift.io
+          resources:
+          - csiaddonsnodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - groupsnapshot.storage.openshift.io
+          resources:
+          - volumegroupsnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - alertmanagers
@@ -243,6 +267,7 @@ spec:
         - apiGroups:
           - ocs.openshift.io
           resources:
+          - storageclients
           - storageclusters
           verbs:
           - get

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -8,19 +8,19 @@ data:
     csv: cephcsi-operator.v4.22.0
     pkg: cephcsi-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - operatorconfigs.csi.ceph.io
   CSIADDONS: |
     channel: alpha
     csv: csi-addons.v0.14.0
     pkg: csi-addons
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - csiaddonsnodes.csiaddons.openshift.io
   SNAPSHOT_CONTROLLER: |
     channel: alpha
     csv: odf-external-snapshotter-operator.v4.22.0
     pkg: odf-external-snapshotter-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io
   IBM_ODF: |
     channel: stable-v1.8
     csv: ibm-storage-odf-operator.v1.8.0
@@ -44,7 +44,7 @@ data:
     csv: ocs-client-operator.v4.22.0
     pkg: ocs-client-operator
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - storageclients.ocs.openshift.io
   OCS: |
     channel: alpha
     csv: ocs-operator.v4.22.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,30 @@ rules:
   - list
   - update
 - apiGroups:
+  - csi.ceph.io
+  resources:
+  - operatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers
@@ -143,6 +167,7 @@ rules:
 - apiGroups:
   - ocs.openshift.io
   resources:
+  - storageclients
   - storageclusters
   verbs:
   - get

--- a/controllers/operatorscaler_controller.go
+++ b/controllers/operatorscaler_controller.go
@@ -94,6 +94,10 @@ type OperatorScalerReconciler struct {
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch
+//+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclients,verbs=get;list;watch
+//+kubebuilder:rbac:groups=csi.ceph.io,resources=operatorconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=csiaddons.openshift.io,resources=csiaddonsnodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=groupsnapshot.storage.openshift.io,resources=volumegroupsnapshotclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=odf.ibm.com,resources=flashsystemclusters,verbs=get;list;watch

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -38,19 +38,19 @@ data:
     csv: $(CEPHCSI_SUBSCRIPTION_CSVNAME)
     pkg: $(CEPHCSI_SUBSCRIPTION_PACKAGE)
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - operatorconfigs.csi.ceph.io
   CSIADDONS: |
     channel: $(CSIADDONS_SUBSCRIPTION_CHANNEL)
     csv: $(CSIADDONS_SUBSCRIPTION_CSVNAME)
     pkg: $(CSIADDONS_SUBSCRIPTION_PACKAGE)
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - csiaddonsnodes.csiaddons.openshift.io
   SNAPSHOT_CONTROLLER: |
     channel: $(ODF_SNAPSHOT_CONTROLLER_SUBSCRIPTION_CHANNEL)
     csv: $(ODF_SNAPSHOT_CONTROLLER_SUBSCRIPTION_CSVNAME)
     pkg: $(ODF_SNAPSHOT_CONTROLLER_SUBSCRIPTION_PACKAGE)
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io
   IBM_ODF: |
     channel: $(IBM_ODF_SUBSCRIPTION_CHANNEL)
     csv: $(IBM_ODF_SUBSCRIPTION_CSVNAME)
@@ -74,7 +74,7 @@ data:
     csv: $(OCS_CLIENT_SUBSCRIPTION_CSVNAME)
     pkg: $(OCS_CLIENT_SUBSCRIPTION_PACKAGE)
     scaleUpOnInstanceOf:
-      - cephclusters.ceph.rook.io
+      - storageclients.ocs.openshift.io
   OCS: |
     channel: $(OCS_SUBSCRIPTION_CHANNEL)
     csv: $(OCS_SUBSCRIPTION_CSVNAME)

--- a/pkg/deploymanager/operatorscaler.go
+++ b/pkg/deploymanager/operatorscaler.go
@@ -9,6 +9,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,10 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 		//nolint:errcheck
 		defer d.ScaleDownCsvsDeploymentsReplicas(kindCsvRecord.CsvNames, kindCsvRecord.Namespace)
 		d.Log.Info("cleanup", "csvs", kindCsvRecord.CsvNames)
+		// Cleanup: Remove finalizers for the CR deletion
+		patch := []byte(`{"metadata":{"finalizers":[]}}`)
+		//nolint:errcheck
+		defer d.Client.Patch(d.Ctx, obj, client.RawPatch(types.MergePatchType, patch))
 		// Cleanup: Delete the CR
 		//nolint:errcheck
 		defer d.Client.Delete(d.Ctx, obj)

--- a/pkg/deploymanager/operatorscaler.go
+++ b/pkg/deploymanager/operatorscaler.go
@@ -43,86 +43,9 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 			},
 		}
 
-		if kindCsvRecord.Kind == "NooBaa" {
-			// Set the required field
-			if err := unstructured.SetNestedField(
-				obj.Object, true,
-				"spec", "cleanupPolicy", "allowNoobaaDeletion"); err != nil {
-				d.Log.Error(err, "failed to set spec.cleanupPolicy.allowNoobaaDeletion")
-				return err
-			}
-		}
-
-		if kindCsvRecord.Kind == "StorageClient" {
-			// Set the required field
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-onboardingTicket",
-				"spec", "onboardingTicket"); err != nil {
-				d.Log.Error(err, "failed to set spec.onboardingTicket")
-				return err
-			}
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-storageProviderEndpoint",
-				"spec", "storageProviderEndpoint"); err != nil {
-				d.Log.Error(err, "failed to set spec.storageProviderEndpoint")
-				return err
-			}
-		}
-
-		if kindCsvRecord.Kind == "CSIAddonsNode" {
-			// Set the required field
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-driverName",
-				"spec", "driver", "name"); err != nil {
-				d.Log.Error(err, "failed to set spec.driver.name")
-				return err
-			}
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-driverEndpoint",
-				"spec", "driver", "endpoint"); err != nil {
-				d.Log.Error(err, "failed to set spec.driver.endpoint")
-				return err
-			}
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-driverNodeID",
-				"spec", "driver", "nodeID"); err != nil {
-				d.Log.Error(err, "failed to set spec.driver.nodeID")
-				return err
-			}
-		}
-
-		if kindCsvRecord.Kind == "VolumeGroupSnapshotClass" {
-			// Set the required field
-			if err := unstructured.SetNestedField(
-				obj.Object, "Retain",
-				"deletionPolicy"); err != nil {
-				d.Log.Error(err, "failed to set deletionPolicy")
-				return err
-			}
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-driver",
-				"driver"); err != nil {
-				d.Log.Error(err, "failed to set driver")
-				return err
-			}
-			// Remove the spec as it is not a field in this object
-			unstructured.RemoveNestedField(obj.Object, "spec")
-		}
-
-		if kindCsvRecord.Kind == "FlashSystemCluster" {
-			// Set the required field
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-name",
-				"spec", "name"); err != nil {
-				d.Log.Error(err, "failed to set spec.name")
-				return err
-			}
-			if err := unstructured.SetNestedField(
-				obj.Object, "dummy-secret",
-				"spec", "secret", "name"); err != nil {
-				d.Log.Error(err, "failed to set spec.secret.name")
-				return err
-			}
+		if err := d.SetRequiredFields(obj, kindCsvRecord.Kind); err != nil {
+			d.Log.Error(err, "failed to set mandatory fields", "kind", kindCsvRecord.Kind)
+			return err
 		}
 
 		if err := d.Client.Create(d.Ctx, obj); err != nil {
@@ -256,6 +179,93 @@ func (d *DeployManager) ScaleDownCsvsDeploymentsReplicas(csvNames []string, name
 			d.Log.Info("successfully scaled down deployments replicas of csv", "csvName", csvName)
 			return nil
 		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DeployManager) SetRequiredFields(obj *unstructured.Unstructured, kind string) error {
+
+	if kind == "NooBaa" {
+		// Set the required field
+		if err := unstructured.SetNestedField(
+			obj.Object, true,
+			"spec", "cleanupPolicy", "allowNoobaaDeletion"); err != nil {
+			d.Log.Error(err, "failed to set spec.cleanupPolicy.allowNoobaaDeletion")
+			return err
+		}
+	}
+
+	if kind == "StorageClient" {
+		// Set the required field
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-onboardingTicket",
+			"spec", "onboardingTicket"); err != nil {
+			d.Log.Error(err, "failed to set spec.onboardingTicket")
+			return err
+		}
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-storageProviderEndpoint",
+			"spec", "storageProviderEndpoint"); err != nil {
+			d.Log.Error(err, "failed to set spec.storageProviderEndpoint")
+			return err
+		}
+	}
+
+	if kind == "CSIAddonsNode" {
+		// Set the required field
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-driverName",
+			"spec", "driver", "name"); err != nil {
+			d.Log.Error(err, "failed to set spec.driver.name")
+			return err
+		}
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-driverEndpoint",
+			"spec", "driver", "endpoint"); err != nil {
+			d.Log.Error(err, "failed to set spec.driver.endpoint")
+			return err
+		}
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-driverNodeID",
+			"spec", "driver", "nodeID"); err != nil {
+			d.Log.Error(err, "failed to set spec.driver.nodeID")
+			return err
+		}
+	}
+
+	if kind == "VolumeGroupSnapshotClass" {
+		// Set the required field
+		if err := unstructured.SetNestedField(
+			obj.Object, "Retain",
+			"deletionPolicy"); err != nil {
+			d.Log.Error(err, "failed to set deletionPolicy")
+			return err
+		}
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-driver",
+			"driver"); err != nil {
+			d.Log.Error(err, "failed to set driver")
+			return err
+		}
+		// Remove the spec as it is not a field in this object
+		unstructured.RemoveNestedField(obj.Object, "spec")
+	}
+
+	if kind == "FlashSystemCluster" {
+		// Set the required field
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-name",
+			"spec", "name"); err != nil {
+			d.Log.Error(err, "failed to set spec.name")
+			return err
+		}
+		if err := unstructured.SetNestedField(
+			obj.Object, "dummy-secret",
+			"spec", "secret", "name"); err != nil {
+			d.Log.Error(err, "failed to set spec.secret.name")
 			return err
 		}
 	}

--- a/pkg/deploymanager/operatorscaler.go
+++ b/pkg/deploymanager/operatorscaler.go
@@ -44,13 +44,69 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 		}
 
 		if kindCsvRecord.Kind == "NooBaa" {
-			// Set the AllowNoobaaDeletion field
+			// Set the required field
 			if err := unstructured.SetNestedField(
 				obj.Object, true,
 				"spec", "cleanupPolicy", "allowNoobaaDeletion"); err != nil {
-				d.Log.Error(err, "failed to set noobaa cleanup policy")
+				d.Log.Error(err, "failed to set spec.cleanupPolicy.allowNoobaaDeletion")
 				return err
 			}
+		}
+
+		if kindCsvRecord.Kind == "StorageClient" {
+			// Set the required field
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-onboardingTicket",
+				"spec", "onboardingTicket"); err != nil {
+				d.Log.Error(err, "failed to set spec.onboardingTicket")
+				return err
+			}
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-storageProviderEndpoint",
+				"spec", "storageProviderEndpoint"); err != nil {
+				d.Log.Error(err, "failed to set spec.storageProviderEndpoint")
+				return err
+			}
+		}
+
+		if kindCsvRecord.Kind == "CSIAddonsNode" {
+			// Set the required field
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-driverName",
+				"spec", "driver", "name"); err != nil {
+				d.Log.Error(err, "failed to set spec.driver.name")
+				return err
+			}
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-driverEndpoint",
+				"spec", "driver", "endpoint"); err != nil {
+				d.Log.Error(err, "failed to set spec.driver.endpoint")
+				return err
+			}
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-driverNodeID",
+				"spec", "driver", "nodeID"); err != nil {
+				d.Log.Error(err, "failed to set spec.driver.nodeID")
+				return err
+			}
+		}
+
+		if kindCsvRecord.Kind == "VolumeGroupSnapshotClass" {
+			// Set the required field
+			if err := unstructured.SetNestedField(
+				obj.Object, "Retain",
+				"deletionPolicy"); err != nil {
+				d.Log.Error(err, "failed to set deletionPolicy")
+				return err
+			}
+			if err := unstructured.SetNestedField(
+				obj.Object, "dummy-driver",
+				"driver"); err != nil {
+				d.Log.Error(err, "failed to set driver")
+				return err
+			}
+			// Remove the spec as it is not a field in this object
+			unstructured.RemoveNestedField(obj.Object, "spec")
 		}
 
 		if kindCsvRecord.Kind == "FlashSystemCluster" {
@@ -64,7 +120,7 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 			if err := unstructured.SetNestedField(
 				obj.Object, "dummy-secret",
 				"spec", "secret", "name"); err != nil {
-				d.Log.Error(err, "failed to set spec.secret")
+				d.Log.Error(err, "failed to set spec.secret.name")
 				return err
 			}
 		}
@@ -73,6 +129,7 @@ func (d *DeployManager) ValidateOperatorScaler() error {
 			d.Log.Error(err, "failed to create object", "kind", kindCsvRecord.Kind)
 			return err
 		}
+		d.Log.Info("successfully created object", "kind", kindCsvRecord.Kind)
 
 		// Cleanup: Restore CSV replica to original state
 		//nolint:errcheck


### PR DESCRIPTION
Scale is introducing a remote cluster model with a client cluster, where no StorageCluster or CephCluster resources are present locally. ODF will manage these clusters as CNSA will be brought up via ODF only.

Update the scaleUpOnInstanceOf CR entry points to reference the appropriate resources for this architecture instead of CephCluster based triggers, since CephCluster is no longer present. This ensures the client and related operators are scaled up correctly.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>