### PR TITLE
makefile: handle scale-up triggers for all deployment modes

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.22.0_v1_configmap.yaml
+++ b/bundle/odf-operator/manifests/odf-operator-pkgs-config-4.22.0_v1_configmap.yaml
@@ -54,6 +54,9 @@ data:
     pkg: ocs-client-operator
     scaleUpOnInstanceOf:
       - storageclients.ocs.openshift.io
+      # In external mode, no storage client is present, but the client operator
+      # is still required to create the CSI-related CRs.
+      - cephclusters.ceph.rook.io
   ODF_DEPS: |
     channel: alpha
     csv: odf-dependencies.v4.22.0

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -45,6 +45,9 @@ data:
     pkg: ocs-client-operator
     scaleUpOnInstanceOf:
       - storageclients.ocs.openshift.io
+      # In external mode, no storage client is present, but the client operator
+      # is still required to create the CSI-related CRs.
+      - cephclusters.ceph.rook.io
   OCS: |
     channel: alpha
     csv: ocs-operator.v4.22.0

--- a/hack/make-files.mk
+++ b/hack/make-files.mk
@@ -75,6 +75,9 @@ data:
     pkg: $(OCS_CLIENT_SUBSCRIPTION_PACKAGE)
     scaleUpOnInstanceOf:
       - storageclients.ocs.openshift.io
+      # In external mode, no storage client is present, but the client operator
+      # is still required to create the CSI-related CRs.
+      - cephclusters.ceph.rook.io
   OCS: |
     channel: $(OCS_SUBSCRIPTION_CHANNEL)
     csv: $(OCS_SUBSCRIPTION_CSVNAME)


### PR DESCRIPTION
Add CephCluster as a entry point point for ocs-client-operator to support external mode deployments.

Operator scaling behavior now aligns with all supported configurations:
- Internal mode (local client): both StorageClient and CephCluster exist, scaling can be triggered by either.
- Internal mode (remote client / Fusion): only StorageClient exists, scaling depends on storageclient
- External mode: no StorageClient is present, CephCluster is the only available signal, so scaling depends on cephclusters

This ensures the client operator is correctly scaled even in external mode, where it is still required to create CSI-related CRs.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://redhat.atlassian.net/browse/DFBUGS-6416
