### PR TITLE
controllers: handle non-default replica counts for specific deployments

### DIFF
--- a/controllers/operatorscaler_controller.go
+++ b/controllers/operatorscaler_controller.go
@@ -60,6 +60,13 @@ var (
 			return false
 		},
 	}
+
+	// deploymentsWithNonDefaultReplicas maps deployments to their expected replica count
+	// when it differs from the standard single-replica configuration.
+	// This map will be used to scale such deployments.
+	deploymentsWithNonDefaultReplicas = map[string]int32{
+		"odf-external-snapshotter-operator": 2,
+	}
 )
 
 type KindCsvsRecord struct {
@@ -303,9 +310,15 @@ func (r *OperatorScalerReconciler) updateCsvDeplymentsReplicas(ctx context.Conte
 
 	var updateRequired bool
 	for i := range csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		deploymentName := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Name
 		deploymentSpec := &csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Spec
 		if deploymentSpec.Replicas == nil || *deploymentSpec.Replicas < 1 {
+			// set default replica count
 			deploymentSpec.Replicas = ptr.To(int32(1))
+			// override default replica count if required
+			if replicaCount, ok := deploymentsWithNonDefaultReplicas[deploymentName]; ok {
+				deploymentSpec.Replicas = ptr.To(replicaCount)
+			}
 			updateRequired = true
 		}
 	}


### PR DESCRIPTION
Ensure all CSV deployments have a valid replica count by defaulting to 1. Introduce a configurable map to override this default for specific deployments that require higher replica counts.

This prevents under-scaling of deployments that are expected to run with more than one replica.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://redhat.atlassian.net/browse/DFBUGS-6018