### PR TITLE
console: add proxy declaration for S3Vector service

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -170,7 +170,7 @@ func GetConsolePluginCR(consolePort int32, serviceNamespace string) *consolev1.C
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.22") {
+	if strings.Contains(clusterVersion, "4.23") || strings.Contains(clusterVersion, "5.0") {
 		return COMPATIBILITY_BASE_PATH
 	}
 

--- a/console/console.go
+++ b/console/console.go
@@ -131,6 +131,18 @@ func GetConsolePluginProxy(serviceNamespace string) []consolev1.ConsolePluginPro
 			},
 			Authorization: consolev1.None,
 		},
+		{
+			Alias: "s3Vector",
+			Endpoint: consolev1.ConsolePluginProxyEndpoint{
+				Type: consolev1.ProxyTypeService,
+				Service: &consolev1.ConsolePluginProxyServiceConfig{
+					Name:      "vectors",
+					Namespace: serviceNamespace,
+					Port:      443,
+				},
+			},
+			Authorization: consolev1.None,
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/DFBUGS-6388

ODF 4.22 supports OCP 4.22 and 4.23.