### PR TITLE
ux-backend: replace hardcoded ux-backend-secret with random keygen

### DIFF
--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -41,6 +41,8 @@ import (
 	"github.com/red-hat-storage/odf-operator/pkg/util"
 )
 
+const rotatedVersionAnnotationKey = "odf.openshift.io/rotated-version"
+
 // ClusterVersionReconciler reconciles a ClusterVersion object
 type ClusterVersionReconciler struct {
 	client.Client
@@ -231,10 +233,23 @@ func (r *ClusterVersionReconciler) ensureUXBackendServer(ctx context.Context) er
 
 	logger.Info("Ensuring UX backend server secret")
 	uxBackendServerSecret := getUXBackendServerSecret()
-	secretData := uxBackendServerSecret.StringData
+	odfMajorMinorVersion := fmt.Sprintf("%d.%d", odfCsv.Spec.Version.Major, odfCsv.Spec.Version.Minor)
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, uxBackendServerSecret, func() error {
 		uxBackendServerSecret.SetOwnerReferences(nil)
-		uxBackendServerSecret.StringData = secretData
+		currentVersion := uxBackendServerSecret.Annotations[rotatedVersionAnnotationKey]
+		if currentVersion != odfMajorMinorVersion {
+			secret, err := generateSessionSecret()
+			if err != nil {
+				return fmt.Errorf("failed to generate session secret: %w", err)
+			}
+			uxBackendServerSecret.StringData = map[string]string{
+				"session_secret": secret,
+			}
+			if uxBackendServerSecret.Annotations == nil {
+				uxBackendServerSecret.Annotations = make(map[string]string)
+			}
+			uxBackendServerSecret.Annotations[rotatedVersionAnnotationKey] = odfMajorMinorVersion
+		}
 		return controllerutil.SetControllerReference(odfCsv, uxBackendServerSecret, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("failed to create or update UX backend server secret: %w", err)

--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,10 +15,17 @@ import (
 )
 
 const (
-	random30CharacterString = "KP7TThmSTZegSGmHuPKLnSaaAHSG3RSgqw6akBj0oVk"
-	uxBackendProxyName      = "ux-backend-proxy"
-	uxCertName              = "ux-cert-secret"
+	uxBackendProxyName = "ux-backend-proxy"
+	uxCertName         = "ux-cert-secret"
 )
+
+func generateSessionSecret() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random session secret: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
+}
 
 func getUXBackendServerDeployment(tolerations []corev1.Toleration) *appsv1.Deployment {
 
@@ -199,16 +209,12 @@ func getUXBackendServerDeployment(tolerations []corev1.Toleration) *appsv1.Deplo
 }
 
 func getUXBackendServerSecret() *corev1.Secret {
-	secret := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      uxBackendProxyName,
 			Namespace: OperatorNamespace,
 		},
 	}
-	secret.StringData = map[string]string{
-		"session_secret": random30CharacterString,
-	}
-	return secret
 }
 
 func getUXBackendServerService() *corev1.Service {


### PR DESCRIPTION
Instead of hardcoded key now ux-backend-secret uses random secret. Annotatation of odf major.minor version is added to secret. 
Keys are rotated on every ODF minor version upgrade.