### PR TITLE
[release-4.16] Bump go (stdlib: net/http) from 1.21 to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/IBM/ibm-storage-odf-operator v1.5.1


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `go.mod`)
