### PR TITLE
[release-4.17] Bump go (stdlib: net/http) from 1.22.0 to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/IBM/ibm-storage-odf-operator v1.6.0


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.22.0` → `1.22.2` (in `go.mod`)
