### PR TITLE
[main] Bump go (stdlib) from 1.25.7 to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.7` → `1.26.1` (in `go.mod`)
