### PR TITLE
DFBUGS-8450: [release-4.16] Bump go (stdlib) from 1.21.9 to 1.21.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.21.9
+go 1.21.13
 
 require (
 	github.com/IBM/ibm-storage-odf-operator v1.5.1


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21.9` → `1.21.13` (in `go.mod`)
