### PR TITLE
Updated pods to have annotations with openshift.io/required-scc

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -405,6 +405,7 @@ spec:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
+                openshift.io/required-scc: restricted-v2
               labels:
                 app.kubernetes.io/name: odf-operator
                 control-plane: controller-manager
@@ -502,6 +503,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                openshift.io/required-scc: restricted-v2
               labels:
                 app: odf-console
             spec:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -9,6 +9,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         app: odf-console
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        openshift.io/required-scc: restricted-v2
       labels:
         app.kubernetes.io/name: odf-operator
         control-plane: controller-manager

--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -51,6 +51,9 @@ func getUXBackendServerDeployment(tolerations []corev1.Toleration) *appsv1.Deplo
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,
+				Annotations: map[string]string{
+					"openshift.io/required-scc": "restricted-v2",
+				},
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/services/devicefinder/assets/template.go
+++ b/services/devicefinder/assets/template.go
@@ -30,6 +30,7 @@ func NewDeviceFinderDaemonSet(namespace string, containerImage string) *appsv1.D
 					},
 					Annotations: map[string]string{
 						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+						"openshift.io/required-scc":               "privileged",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION

Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) [Enforce least-privileged Security Context Constraint (SCC) across ODF pods ](https://redhat.atlassian.net/browse/RHSTOR-8757)
Summary
Pin every pod template owned by odf-operator to an explicit Security Context Constraint using the openshift.io/required-scc annotation. This makes SCC assignment deterministic for audit and compliance, instead of relying on OpenShift admission to pick the most permissive matching SCC at runtime.

Changes cover all four workloads managed by this operator:

- odf-operator-controller-manager — restricted-v2 (config/manager/manager.yaml, bundle CSV)
- odf-console — restricted-v2 (config/console/console_init.yaml, bundle CSV)
- ux-backend-server — restricted-v2 (controllers/uxbackend.go, runtime Deployment)
- devicefinder-discovery — privileged (services/devicefinder/assets/template.go, runtime DaemonSet; requires host /dev access and a privileged container)
- devicefinder-discovery keeps its existing target.workload.openshift.io/management annotation; the privileged SCC annotation is added alongside it.