### PR TITLE
DFBUGS-5481: [release-4.17] Bump go (stdlib) from 1.22.2 to 1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.22.2
+go 1.22.12
 
 require (
 	github.com/IBM/ibm-storage-odf-operator v1.6.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.22.2` → `1.22.12` (in `go.mod`)
