### PR TITLE
DFBUGS-5508: [release-4.19] Bump go (stdlib) from 1.23.1 to 1.23.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.23.1
+go 1.23.10
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.1` → `1.23.10` (in `go.mod`)
