### PR TITLE
DFBUGS-8452: [release-4.21] Bump go (stdlib) from 1.24.10 to 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.24.10
+go 1.24.12
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `go.mod`)
