### PR TITLE
DFBUGS-8451: [release-4.20] Bump go (stdlib) from 1.24.3 to 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.24.3
+go 1.24.12
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.3` → `1.24.12` (in `go.mod`)
