### PR TITLE
controllers: fix ConsolePlugin proxy entries overwrite in ensureConsolePlugin

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -146,6 +146,35 @@ func GetConsolePluginProxy(serviceNamespace string) []consolev1.ConsolePluginPro
 	}
 }
 
+// MergeConsolePluginProxy merges the desired proxy entries into the existing
+// list, preserving any entries added by other controllers (e.g. ocs-operator).
+// Entries owned by this operator (matched by alias) are updated in place;
+// unknown entries are kept as-is.
+func MergeConsolePluginProxy(existing []consolev1.ConsolePluginProxy, serviceNamespace string, removeAliases []string) []consolev1.ConsolePluginProxy {
+	aliasesToRemove := make(map[string]bool, len(removeAliases))
+	for _, alias := range removeAliases {
+		aliasesToRemove[alias] = true
+	}
+
+	desired := GetConsolePluginProxy(serviceNamespace)
+
+	desiredAliases := make(map[string]bool, len(desired))
+	for _, proxy := range desired {
+		desiredAliases[proxy.Alias] = true
+	}
+
+	merged := append([]consolev1.ConsolePluginProxy{}, desired...)
+
+	for _, proxy := range existing {
+		if aliasesToRemove[proxy.Alias] || desiredAliases[proxy.Alias] {
+			continue
+		}
+		merged = append(merged, proxy)
+	}
+
+	return merged
+}
+
 func GetConsolePluginCR(consolePort int32, serviceNamespace string) *consolev1.ConsolePlugin {
 	return &consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -1,0 +1,113 @@
+package console
+
+import (
+	"testing"
+
+	consolev1 "github.com/openshift/api/console/v1"
+)
+
+func TestMergeConsolePluginProxy_PreservesUnknownEntries(t *testing.T) {
+	ns := "openshift-storage"
+	extra := consolev1.ConsolePluginProxy{
+		Alias: "internalRgwS3",
+		Endpoint: consolev1.ConsolePluginProxyEndpoint{
+			Type: consolev1.ProxyTypeService,
+			Service: &consolev1.ConsolePluginProxyServiceConfig{
+				Name:      "rook-ceph-rgw-ocs-storagecluster-cephobjectstore",
+				Namespace: ns,
+				Port:      443,
+			},
+		},
+		Authorization: consolev1.None,
+	}
+
+	existing := append(GetConsolePluginProxy(ns), extra)
+	merged := MergeConsolePluginProxy(existing, ns, nil)
+
+	found := false
+	for _, p := range merged {
+		if p.Alias == "internalRgwS3" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("MergeConsolePluginProxy dropped the internalRgwS3 entry added by another controller")
+	}
+
+	desired := GetConsolePluginProxy(ns)
+	if len(merged) != len(desired)+1 {
+		t.Errorf("expected %d proxy entries, got %d", len(desired)+1, len(merged))
+	}
+}
+
+func TestMergeConsolePluginProxy_UpdatesKnownEntries(t *testing.T) {
+	ns := "openshift-storage"
+	stale := []consolev1.ConsolePluginProxy{
+		{
+			Alias: "provider-proxy",
+			Endpoint: consolev1.ConsolePluginProxyEndpoint{
+				Type: consolev1.ProxyTypeService,
+				Service: &consolev1.ConsolePluginProxyServiceConfig{
+					Name:      "old-name",
+					Namespace: ns,
+					Port:      1234,
+				},
+			},
+			Authorization: consolev1.None,
+		},
+	}
+
+	merged := MergeConsolePluginProxy(stale, ns, nil)
+
+	for _, p := range merged {
+		if p.Alias == "provider-proxy" {
+			if p.Endpoint.Service.Name != "ux-backend-proxy" || p.Endpoint.Service.Port != 8888 {
+				t.Errorf("expected provider-proxy to be updated, got service=%s port=%d",
+					p.Endpoint.Service.Name, p.Endpoint.Service.Port)
+			}
+			return
+		}
+	}
+	t.Error("provider-proxy not found in merged result")
+}
+
+func TestMergeConsolePluginProxy_EmptyExisting(t *testing.T) {
+	ns := "openshift-storage"
+	merged := MergeConsolePluginProxy(nil, ns, nil)
+	desired := GetConsolePluginProxy(ns)
+
+	if len(merged) != len(desired) {
+		t.Errorf("expected %d proxy entries from empty existing, got %d", len(desired), len(merged))
+	}
+}
+
+func TestMergeConsolePluginProxy_RemovesAliases(t *testing.T) {
+	ns := "openshift-storage"
+	extra := consolev1.ConsolePluginProxy{
+		Alias: "internalRgwS3",
+		Endpoint: consolev1.ConsolePluginProxyEndpoint{
+			Type: consolev1.ProxyTypeService,
+			Service: &consolev1.ConsolePluginProxyServiceConfig{
+				Name:      "rook-ceph-rgw-ocs-storagecluster-cephobjectstore",
+				Namespace: ns,
+				Port:      443,
+			},
+		},
+		Authorization: consolev1.None,
+	}
+
+	existing := append(GetConsolePluginProxy(ns), extra)
+	merged := MergeConsolePluginProxy(existing, ns, []string{"internalRgwS3"})
+
+	for _, p := range merged {
+		if p.Alias == "internalRgwS3" {
+			t.Error("MergeConsolePluginProxy should remove entries matching removeAliases")
+		}
+	}
+
+	desired := GetConsolePluginProxy(ns)
+	if len(merged) != len(desired) {
+		t.Errorf("expected %d proxy entries after removal, got %d", len(desired), len(merged))
+	}
+}

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -177,7 +177,9 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(ctx context.Context, clus
 				odfConsolePlugin.Spec.Backend.Service.BasePath = basePath
 			}
 		}
-		odfConsolePlugin.Spec.Proxy = console.GetConsolePluginProxy(OperatorNamespace)
+		// MergeConsolePluginProxy merges the desired proxy entries into the existing.
+		// To remove stale proxy entries, pass the aliases of the stale entries to the function (currently nil)
+		odfConsolePlugin.Spec.Proxy = console.MergeConsolePluginProxy(odfConsolePlugin.Spec.Proxy, OperatorNamespace, nil)
 		return nil
 	})
 	if err != nil && !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
## Summary
- `ensureConsolePlugin` unconditionally replaced the entire `spec.proxy` list on the `odf-console` ConsolePlugin every reconcile, discarding proxy entries added by other controllers (e.g. `internalRgwS3` from ocs-operator)
- This caused an infinite reconcile loop where ocs-operator added the entry and odf-operator immediately removed it, generating tens of thousands of unnecessary API writes
- Added `MergeConsolePluginProxy()` that updates known entries in place while preserving unknown entries from other controllers

## Root Cause

In `clusterversion_controller.go:180`, the mutate function inside `controllerutil.CreateOrUpdate` did:
```go
odfConsolePlugin.Spec.Proxy = console.GetConsolePluginProxy(OperatorNamespace)
```
This replaced the full proxy slice with a hard-coded 5-entry list, removing the `internalRgwS3` entry that `ocs-operator` appends. Since `CreateOrUpdate` uses a full-object `Update` (not patch/SSA), the removal was written to the API server, triggering the ocs-operator to add it back.

## Fix

Replace the full-list assignment with a merge operation:
```go
odfConsolePlugin.Spec.Proxy = console.MergeConsolePluginProxy(odfConsolePlugin.Spec.Proxy, OperatorNamespace)
```
`MergeConsolePluginProxy` iterates the existing proxy list, updates entries with matching aliases to their desired state, and preserves entries with unknown aliases.

## Test plan
- [x] Unit tests for `MergeConsolePluginProxy` covering: preserving unknown entries, updating known entries, empty existing list
- [x] `go build ./...` passes
- [x] `go test ./console/` passes

Fixes: https://github.com/red-hat-storage/odf-operator/issues/867