### PR TITLE
[main] Bump go (stdlib) from 1.25.7 to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-operator
 
-go 1.25.7
+go 1.25.10
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.7` → `1.25.10` (in `go.mod`)
