### PR TITLE
bundle: lower odf-operator CPU request from 200m to 10m

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -465,7 +465,7 @@ spec:
                     cpu: 200m
                     memory: 400Mi
                   requests:
-                    cpu: 200m
+                    cpu: 10m
                     memory: 400Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,7 +71,7 @@ spec:
             cpu: 200m
             memory: 400Mi
           requests:
-            cpu: 200m
+            cpu: 10m
             memory: 400Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The 200m CPU request was added in #48 as part of raising manager resources. That value was mostly an approximation, not based on measured needs. Operator pods are mostly idle and only briefly wake to reconcile. The past perf tests showed that the average CPU usage of the operator pods is very very low too. So lower the request to 10m and keep the 200m limit so bursts are still allowed if needed.

Ref-https://redhat.atlassian.net/browse/RHSTOR-9517