### PR TITLE
bundle: lower ux-backend-server CPU request from 50m to 10m

### DIFF
--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -115,7 +115,7 @@ func getUXBackendServerDeployment(tolerations []corev1.Toleration) *appsv1.Deplo
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
 							Limits: corev1.ResourceList{


### PR DESCRIPTION
The 50m CPU request was added in #719 when resource requirements were first set on the ux-backend-server deployment. That value was a pure approximation, not based on measured needs. ux-backend-server is a request-driven Go HTTP API for the console, not an operator reconcile loop: handlers do light Kubernetes Get/List/Create/Update and JSON work, and heavier tasks such as device discovery are offloaded to DaemonSets. Aside from a small informer cache, the pod is idle most of the time and only briefly wakes on UI calls, so lower the request to 10m and keep the 250m limit so bursts are still allowed. Leave the oauth-proxy sidecar at 5m.