### PR TITLE
bundle: set odf-console CPU request to 10m

### DIFF
--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -528,7 +528,7 @@ spec:
                     memory: 512Mi
                   requests:
                     cpu: 10m
-                    memory: 512Mi
+                    memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
+++ b/bundle/odf-operator/manifests/odf-operator.clusterserviceversion.yaml
@@ -526,6 +526,9 @@ spec:
                   limits:
                     cpu: 100m
                     memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 512Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -22,6 +22,9 @@ spec:
             limits:
               cpu: "100m"
               memory: "512Mi"
+            requests:
+              cpu: "10m"
+              memory: "512Mi"
           livenessProbe:
             httpGet:
               path: /plugin-manifest.json

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -24,7 +24,7 @@ spec:
               memory: "512Mi"
             requests:
               cpu: "10m"
-              memory: "512Mi"
+              memory: "256Mi"
           livenessProbe:
             httpGet:
               path: /plugin-manifest.json


### PR DESCRIPTION
odf-console currently sets only a 100m CPU limit and no request. When a limit is set without a request, Kubernetes defaults the request to match the limit, so the pod effectively reserves 100m.

odf-console is an OpenShift Console dynamic plugin that serves static TypeScript/React assets via nginx; it is idle most of the time and only briefly serves HTTPS static files when the console loads the plugin. The [OpenShift console-plugin-template](https://github.com/openshift/console-plugin-template/blob/016aab8b614caec0db4e8812e6414970a74ee039/charts/openshift-console-plugin/values.yaml#L25) defaults to a 10m CPU request for the same workload pattern. Set an explicit 10m request and keep the 100m limit so bursts are still allowed.