### PR TITLE
console: update compatibility support matrix for 4.23

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -196,7 +196,7 @@ func GetConsolePluginCR(consolePort int32, serviceNamespace string) *consolev1.C
 }
 
 func GetBasePath(clusterVersion string) string {
-	if strings.Contains(clusterVersion, "4.23") || strings.Contains(clusterVersion, "5.0") {
+	if strings.Contains(clusterVersion, "4.24") || strings.Contains(clusterVersion, "5.1") {
 		return COMPATIBILITY_BASE_PATH
 	}
 


### PR DESCRIPTION
ODF 4.23 supports OCP 4.23 and 4.24/5.1.