### PR TITLE
ci: correct dependabot package-ecosystem name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
 
   # Go module dependencies
-  - package-ecosystem: "go-modules"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
