### PR TITLE
console: allow openshift-storage ingress to ux-backend-proxy

### DIFF
--- a/controllers/uxbackend.go
+++ b/controllers/uxbackend.go
@@ -258,15 +258,25 @@ func getUXBackendServerNetworkPolicy() *networkingv1.NetworkPolicy {
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "ux-backend-server"}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				From: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"kubernetes.io/metadata.name": "openshift-console",
-					}},
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"app":       "console",
-						"component": "ui",
-					}},
-				}},
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "openshift-console",
+						}},
+						PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"app":       "console",
+							"component": "ui",
+						}},
+					},
+					{
+						// Allow the multicluster orchestrator addon agent (runs in
+						// openshift-storage) to reach /onboarding/peer-tokens for
+						// MirrorPeer peering.
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": OperatorNamespace,
+						}},
+					},
+				},
 				Ports: []networkingv1.NetworkPolicyPort{{
 					Protocol: &protocol,
 					Port:     &intstr.IntOrString{IntVal: 8888},


### PR DESCRIPTION
The `ux-backend-proxy` NetworkPolicy only allowed ingress from `openshift-console` pods. 
This blocked the multicluster orchestrator addon agent (running in `openshift-storage`) from reaching 
`/onboarding/peer-tokens`, causing `MirrorPeer` creation to get stuck in `Configuring` phase with a timeout error.

Add `openshift-storage` as an allowed ingress source namespace so the addon agent can generate peer onboarding tokens.

Before PR:
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: ux-backend-proxy
  namespace: openshift-storage
spec:
  podSelector:
    matchLabels:
      app: ux-backend-server
  policyTypes:
    - Ingress
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: openshift-console
          podSelector:
            matchLabels:
              app: console
              component: ui
      ports:
        - protocol: TCP
          port: 8888
```

After fix (proposed):
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: ux-backend-proxy
  namespace: openshift-storage
spec:
  podSelector:
    matchLabels:
      app: ux-backend-server
  policyTypes:
    - Ingress
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: openshift-console
          podSelector:
            matchLabels:
              app: console
              component: ui
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: openshift-storage
      ports:
        - protocol: TCP
          port: 8888
```